### PR TITLE
[Fix] #22 - Font 파일 내 상수 중복 정의 오류 수정

### DIFF
--- a/playkuround-iOS/Resources/Font.swift
+++ b/playkuround-iOS/Resources/Font.swift
@@ -18,5 +18,4 @@ extension Font {
     static let pretendard12R: Font = .custom("Pretendard-Regular", size: 12)
     static let pretendard14R: Font = .custom("Pretendard-Regular", size: 14)
     static let pretendard15R: Font = .custom("Pretendard-Regular", size: 15)
-    static let pretendard12R: Font = .custom("Pretendard-Regular", size: 12)
 }


### PR DESCRIPTION
### 🐣Issue
#22 
<br/>

### 🐣Motivation
`Font.swift` 파일 내 `pretendard12R` 상수가 두 번 정의되는 오류가 있었습니다
Merge하면서 conflict가 발생한 것 같아 수정했습니다
<br/>

### 🐣Key Changes
`pretendard12R` 정의 구문을 제거하여 오류를 해결했습니다!
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
main branch pull origin 해보니 오류가 있어서 수정했습니다!
<br/>

### 🐣Reference
X
<br/>
