### PR TITLE
[Fix] #24 - APIManager 토큰 없이 특정 API 호출 실패하는 오류 수정

### DIFF
--- a/playkuround-iOS/Extensions/Managers/APIManager.swift
+++ b/playkuround-iOS/Extensions/Managers/APIManager.swift
@@ -351,10 +351,13 @@ extension APIManager {
         }
         
         // 토큰 불러오기
-        let accessToken = TokenManager.token(tokenType: .access)
-        if accessToken.isEmpty {
-            completion(.failure(NSError(domain: "No Access Token Found", code: 401)))
-            return
+        // availability, emails API는 토큰 필요 없음
+        if endpoint != .availability && endpoint != .emails {
+            let accessToken = TokenManager.token(tokenType: .access)
+            if accessToken.isEmpty {
+                completion(.failure(NSError(domain: "No Access Token Found", code: 401)))
+                return
+            }
         }
         
         // API 요청 함수 호출
@@ -436,11 +439,14 @@ extension APIManager {
         }
         
         // 토큰 불러오기
-        let accessToken = TokenManager.token(tokenType: .access)
-        print("accessToken: " + accessToken)
-        if accessToken.isEmpty {
-            completion(.failure(NSError(domain: "No Access Token Found", code: 401)))
-            return
+        // reissue, emails, register API는 토큰 없이 호출 가능
+        if endpoint != .reissue && endpoint != .emails && endpoint != .register {
+            let accessToken = TokenManager.token(tokenType: .access)
+            print("accessToken: " + accessToken)
+            if accessToken.isEmpty {
+                completion(.failure(NSError(domain: "No Access Token Found", code: 401)))
+                return
+            }
         }
         
         // API 요청 함수 호출
@@ -722,6 +728,10 @@ struct APIManagerTestView: View {
                     }
                 }
             }
+        }
+        .onAppear {
+            // 테스트 하기 위해 토큰을 제거
+            TokenManager.reset()
         }
     }
 }


### PR DESCRIPTION
### 🐣Issue
#24 
<br/>

### 🐣Motivation
APIManager에서 토큰이 필요 없는 일부 API 호출에 실패하는 오류 수정
<br/>

### 🐣Key Changes
Wrapping 함수인 `callPOSTAPI`와 `callGETAPI` 함수에서 토큰이 필요 없는 API에 대해 예외 처리를 했어야 하나, 빠져 있어 호출 시 토큰이 없는 문제로 API 호출이 실패하던 오류 수정
<br/>
```swift
// func callGETAPI()
// availability, emails API는 토큰 필요 없음
if endpoint != .availability && endpoint != .emails {
    let accessToken = TokenManager.token(tokenType: .access)
    if accessToken.isEmpty {
        completion(.failure(NSError(domain: "No Access Token Found", code: 401)))
        return
    }
}
```

```swift
// func callPOSTAPI()
// reissue, emails, register API는 토큰 없이 호출 가능
if endpoint != .reissue && endpoint != .emails && endpoint != .register {
    let accessToken = TokenManager.token(tokenType: .access)
    print("accessToken: " + accessToken)
    if accessToken.isEmpty {
        completion(.failure(NSError(domain: "No Access Token Found", code: 401)))
        return
    }
}
```
위와 같이 각각의 함수에서 특정 API에 대하여 예외 처리하여 오류 수정하였습니다!

```swift
// ...
.onAppear {
    // 테스트 하기 위해 토큰을 제거
    TokenManager.reset()
}
```
테스트 하기 위해 위와 같이 토큰을 제거한 후 테스트 하였고, 이상이 없었습니다.
<br/>

### 🐣Simulation
// UI를 구현했다면 시연영상은 필수 !
X
<br/>

### 🐣To Reviewer
미처 생각하지 못했던 부분을 짚어주셔서 일이 커지기 전에 해결할 수 있었네요 감사합니다👍🏻
앞으론 테스트를 더 꼼꼼하게 하도록 하겠습니다 🥲
<br/>

### 🐣Reference
X
<br/>
