### PR TITLE
[Fix] #21 - 회원가입 관련 뷰 버튼 구현 방식 수정 및 자간 적용

### DIFF
--- a/playkuround-iOS/Views/Register/RegisterMajorView.swift
+++ b/playkuround-iOS/Views/Register/RegisterMajorView.swift
@@ -34,6 +34,7 @@ struct RegisterView: View {
                 
                 Text(StringLiterals.Register.college)
                     .font(.neo15)
+                    .kerning(-0.41)
                     .foregroundStyle(.kuText)
                 
                 // 단과대 Menu Button
@@ -66,6 +67,7 @@ struct RegisterView: View {
                 
                 Text(StringLiterals.Register.major)
                     .font(.neo15)
+                    .kerning(-0.41)
                     .foregroundStyle(.kuText)
                 
                 // 학과 Menu Button
@@ -107,6 +109,7 @@ struct RegisterView: View {
                     .overlay {
                         Text(StringLiterals.Register.next)
                             .font(.neo15)
+                            .kerning(-0.41)
                             .foregroundStyle(.kuText)
                     }
                     .onTapGesture {

--- a/playkuround-iOS/Views/Register/RegisterMajorView.swift
+++ b/playkuround-iOS/Views/Register/RegisterMajorView.swift
@@ -100,21 +100,18 @@ struct RegisterView: View {
                 Spacer()
                 
                 // 다음 버튼
-                Button {
-                    // TODO: 다음으로 넘어가는 transition 구현
-                } label: {
-                    Image((selectedCollege != nil && selectedMajor != nil) ? .longButtonBlue : .longButtonGray)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            Text(StringLiterals.Register.next)
-                                .font(.neo15)
-                                .foregroundStyle(.kuText)
-                        }
-                }
-                // 버튼 애니메이션 제거
-                .buttonStyle(PlainButtonStyle())
+                Image((selectedCollege != nil && selectedMajor != nil) ? .longButtonBlue : .longButtonGray)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        Text(StringLiterals.Register.next)
+                            .font(.neo15)
+                            .foregroundStyle(.kuText)
+                    }
+                    .onTapGesture {
+                        // TODO: 다음으로 넘어가는 transition 구현
+                    }
             }
             .padding(.horizontal)
             .padding(.top, 30)

--- a/playkuround-iOS/Views/Register/RegisterNickname.swift
+++ b/playkuround-iOS/Views/Register/RegisterNickname.swift
@@ -98,61 +98,60 @@ struct RegisterNickname: View {
                 
                 Spacer()
                 
-                Button {
-                    // 닉네임 올바른지 검사
-                    if !isNicknameChecked {
-                        isLoading = true
-                        APIManager.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
-                            switch result {
-                            case .success(let data):
-                                if let response = data as? BoolResponse {
-                                    print("nickname availability: ", response.response)
-                                    if response.response {
-                                        // TODO: 다음 뷰로 이동
-                                        isLoading = false
-                                        print("nickname is available, transfer to next view")
-                                        // TODO: 회원가입 프로세스 진행
+                // 다음 버튼
+                // if 닉네임이 검사된 경우
+                //     if 닉네임이 중복된 경우 deactivate
+                //     else activate
+                // else (닉네임이 검사되기 전)
+                //     if 닉네임이 valid한 경우 active
+                //     else deactivate
+                Image(isNicknameChecked ? (isNicknameDuplicated ? .longButtonGray : .longButtonBlue) : (isNicknameVaild && nickname.count >= 2 ? .longButtonBlue : .longButtonGray))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        if isLoading {
+                            // API 요청한 경우
+                            ProgressView()
+                        } else {
+                            Text(StringLiterals.Register.next)
+                                .font(.neo15)
+                                .foregroundStyle(.kuText)
+                        }
+                    }
+                    .onTapGesture {
+                        // 닉네임 올바른지 검사
+                        if !isNicknameChecked && isNicknameVaild && nickname.count >= 2 {
+                            isLoading = true
+                            APIManager.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
+                                switch result {
+                                case .success(let data):
+                                    if let response = data as? BoolResponse {
+                                        print("nickname availability: ", response.response)
+                                        if response.response {
+                                            // TODO: 다음 뷰로 이동
+                                            isLoading = false
+                                            print("nickname is available, transfer to next view")
+                                            // TODO: 회원가입 프로세스 진행
+                                        } else {
+                                            isNicknameDuplicated = true
+                                            isNicknameChecked = true
+                                            isLoading = false
+                                        }
                                     } else {
                                         isNicknameDuplicated = true
                                         isNicknameChecked = true
                                         isLoading = false
                                     }
-                                } else {
+                                case .failure(let error):
+                                    print("Error in View: \(error)")
                                     isNicknameDuplicated = true
                                     isNicknameChecked = true
                                     isLoading = false
                                 }
-                            case .failure(let error):
-                                print("Error in View: \(error)")
-                                isNicknameDuplicated = true
-                                isNicknameChecked = true
-                                isLoading = false
                             }
                         }
                     }
-                } label: {
-                    // if 닉네임이 검사된 경우
-                    //     if 닉네임이 중복된 경우 deactivate
-                    //     else activate
-                    // else (닉네임이 검사되기 전)
-                    //     if 닉네임이 valid한 경우 active
-                    //     else deactivate
-                    Image(isNicknameChecked ? (isNicknameDuplicated ? .longButtonGray : .longButtonBlue) : (isNicknameVaild && nickname.count >= 2 ? .longButtonBlue : .longButtonGray))
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            if isLoading {
-                                // API 요청한 경우
-                                ProgressView()
-                            } else {
-                                Text(StringLiterals.Register.next)
-                                    .font(.neo15)
-                                    .foregroundStyle(.kuText)
-                            }
-                        }
-                }
-                .buttonStyle(PlainButtonStyle())
             }
             .padding(.horizontal)
             .padding(.top, 30)

--- a/playkuround-iOS/Views/Register/RegisterNickname.swift
+++ b/playkuround-iOS/Views/Register/RegisterNickname.swift
@@ -116,6 +116,7 @@ struct RegisterNickname: View {
                         } else {
                             Text(StringLiterals.Register.next)
                                 .font(.neo15)
+                                .kerning(-0.41)
                                 .foregroundStyle(.kuText)
                         }
                     }

--- a/playkuround-iOS/Views/Register/RegisterNickname.swift
+++ b/playkuround-iOS/Views/Register/RegisterNickname.swift
@@ -136,7 +136,7 @@ struct RegisterNickname: View {
     }
     
     // 서버 API 통해 닉네임이 사용 가능한지 검사
-    func checkNicknameAvailability() {
+    private func checkNicknameAvailability() {
         APIManager.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
             switch result {
             case .success(let data):
@@ -167,7 +167,7 @@ struct RegisterNickname: View {
     }
     
     // 닉네임 체크 (한글, 영어만 가능)
-    func nicknameValidate(_ input: String) -> Bool {
+    private func nicknameValidate(_ input: String) -> Bool {
         let pattern = "^[가-힣a-zA-Z0-9\\s]*$"
         if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
             let range = NSRange(location: 0, length: input.utf16.count)

--- a/playkuround-iOS/Views/Register/RegisterNickname.swift
+++ b/playkuround-iOS/Views/Register/RegisterNickname.swift
@@ -124,39 +124,45 @@ struct RegisterNickname: View {
                         // 닉네임 올바른지 검사
                         if !isNicknameChecked && isNicknameVaild && nickname.count >= 2 {
                             isLoading = true
-                            APIManager.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
-                                switch result {
-                                case .success(let data):
-                                    if let response = data as? BoolResponse {
-                                        print("nickname availability: ", response.response)
-                                        if response.response {
-                                            // TODO: 다음 뷰로 이동
-                                            isLoading = false
-                                            print("nickname is available, transfer to next view")
-                                            // TODO: 회원가입 프로세스 진행
-                                        } else {
-                                            isNicknameDuplicated = true
-                                            isNicknameChecked = true
-                                            isLoading = false
-                                        }
-                                    } else {
-                                        isNicknameDuplicated = true
-                                        isNicknameChecked = true
-                                        isLoading = false
-                                    }
-                                case .failure(let error):
-                                    print("Error in View: \(error)")
-                                    isNicknameDuplicated = true
-                                    isNicknameChecked = true
-                                    isLoading = false
-                                }
-                            }
+                            // 서버에 API 요청해서 닉네임 올바른지 검사
+                            checkNicknameAvailability()
                         }
                     }
             }
             .padding(.horizontal)
             .padding(.top, 30)
             .padding(.bottom, 10)
+        }
+    }
+    
+    // 서버 API 통해 닉네임이 사용 가능한지 검사
+    func checkNicknameAvailability() {
+        APIManager.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
+            switch result {
+            case .success(let data):
+                if let response = data as? BoolResponse {
+                    print("nickname availability: ", response.response)
+                    if response.response {
+                        // TODO: 다음 뷰로 이동
+                        isLoading = false
+                        print("nickname is available, transfer to next view")
+                        // TODO: 회원가입 프로세스 진행
+                    } else {
+                        isNicknameDuplicated = true
+                        isNicknameChecked = true
+                        isLoading = false
+                    }
+                } else {
+                    isNicknameDuplicated = true
+                    isNicknameChecked = true
+                    isLoading = false
+                }
+            case .failure(let error):
+                print("Error in View: \(error)")
+                isNicknameDuplicated = true
+                isNicknameChecked = true
+                isLoading = false
+            }
         }
     }
     

--- a/playkuround-iOS/Views/Register/RegisterTermsView.swift
+++ b/playkuround-iOS/Views/Register/RegisterTermsView.swift
@@ -45,6 +45,7 @@ struct RegisterTermsView: View {
                                 .padding(.trailing, 10)
                             Text(StringLiterals.Register.agreeAllTerms)
                                 .font(.neo15)
+                                .kerning(-0.41)
                                 .foregroundStyle(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .kuText : .white)
                             Spacer()
                         }
@@ -75,6 +76,7 @@ struct RegisterTermsView: View {
                                 .padding(.trailing, 10)
                             Text(StringLiterals.Register.agreeServiceTerms)
                                 .font(.neo15)
+                                .kerning(-0.41)
                                 .foregroundStyle(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .kuText : .white)
                             Spacer()
                             Image(isServiceTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
@@ -105,6 +107,7 @@ struct RegisterTermsView: View {
                                 .padding(.trailing, 10)
                             Text(StringLiterals.Register.agreePrivacyTerms)
                                 .font(.neo15)
+                                .kerning(-0.41)
                                 .foregroundStyle(isPrivacyTermAgreed ? .kuText : .white)
                             Spacer()
                             Image(isPrivacyTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
@@ -136,6 +139,7 @@ struct RegisterTermsView: View {
                                 .padding(.trailing, 10)
                             Text(StringLiterals.Register.agreeLocationTerms)
                                 .font(.neo15)
+                                .kerning(-0.41)
                                 .foregroundStyle(isLocationTermAgreed ? .kuText : .white)
                             Spacer()
                             Image(isLocationTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
@@ -165,6 +169,7 @@ struct RegisterTermsView: View {
                     .overlay {
                         Text(StringLiterals.Register.next)
                             .font(.neo15)
+                            .kerning(-0.41)
                             .foregroundStyle(.kuText)
                     }
                     .onTapGesture {

--- a/playkuround-iOS/Views/Register/RegisterTermsView.swift
+++ b/playkuround-iOS/Views/Register/RegisterTermsView.swift
@@ -35,28 +35,28 @@ struct RegisterTermsView: View {
                     .padding(.bottom, 30)
                 
                 // 전체 동의 버튼
-                Button {
-                    isServiceTermAgreed = true
-                    isPrivacyTermAgreed = true
-                    isLocationTermAgreed = true
-                } label: {
-                    Image(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .longButtonBlue : .longButtonGray)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            HStack {
-                                Image(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .blackCheck : .whiteCheck)
-                                    .padding(.trailing, 10)
-                                Text(StringLiterals.Register.agreeAllTerms)
-                                    .font(.neo15)
-                                    .foregroundStyle(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .kuText : .white)
-                                Spacer()
-                            }
-                            .padding(20)
+                Image(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .longButtonBlue : .longButtonGray)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        HStack {
+                            Image(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .blackCheck : .whiteCheck)
+                                .padding(.trailing, 10)
+                            Text(StringLiterals.Register.agreeAllTerms)
+                                .font(.neo15)
+                                .foregroundStyle(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .kuText : .white)
+                            Spacer()
                         }
-                }
-                .buttonStyle(PlainButtonStyle())
+                        .padding(20)
+                    }
+                    .onTapGesture {
+                        withAnimation(.spring(duration: 0.2)) {
+                            isServiceTermAgreed = true
+                            isPrivacyTermAgreed = true
+                            isLocationTermAgreed = true
+                        }
+                    }
                 
                 Image(.grayLine)
                     .resizable()
@@ -65,112 +65,111 @@ struct RegisterTermsView: View {
                     .padding(.vertical, 3)
                 
                 // 서비스 이용 약관 동의 버튼
-                Button {
-                    isServiceTermAgreed.toggle()
-                } label: {
-                    Image(isServiceTermAgreed ? .longButtonBlue : .longButtonGray)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            HStack {
-                                Image(isServiceTermAgreed ? .blackCheck : .whiteCheck)
-                                    .padding(.trailing, 10)
-                                Text(StringLiterals.Register.agreeServiceTerms)
-                                    .font(.neo15)
-                                    .foregroundStyle(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .kuText : .white)
-                                Spacer()
-                                Image(isServiceTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
-                                    // 버튼 잘 눌릴 수 있게 왼쪽, 위아래로 패딩을 줌
-                                    .padding(.leading, 15)
-                                    .padding(.vertical, 6)
-                                    .onTapGesture {
-                                        // TermsView 보여줌
-                                        isServiceTermsViewPresented = true
-                                    }
-                            }
-                            .padding(20)
+                Image(isServiceTermAgreed ? .longButtonBlue : .longButtonGray)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        HStack {
+                            Image(isServiceTermAgreed ? .blackCheck : .whiteCheck)
+                                .padding(.trailing, 10)
+                            Text(StringLiterals.Register.agreeServiceTerms)
+                                .font(.neo15)
+                                .foregroundStyle(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .kuText : .white)
+                            Spacer()
+                            Image(isServiceTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
+                                // 버튼 잘 눌릴 수 있게 왼쪽, 위아래로 패딩을 줌
+                                .padding(.leading, 15)
+                                .padding(.vertical, 6)
+                                .onTapGesture {
+                                    // TermsView 보여줌
+                                    isServiceTermsViewPresented = true
+                                }
                         }
-                }
-                .buttonStyle(PlainButtonStyle())
+                        .padding(20)
+                    }
+                    .onTapGesture(perform: {
+                        withAnimation(.spring(duration: 0.2)) {
+                            isServiceTermAgreed.toggle()
+                        }
+                    })
                 
                 // 개인정보 수집 및 이용 동의
-                Button {
-                    isPrivacyTermAgreed.toggle()
-                } label: {
-                    Image(isPrivacyTermAgreed ? .longButtonBlue : .longButtonGray)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            HStack {
-                                Image(isPrivacyTermAgreed ? .blackCheck : .whiteCheck)
-                                    .padding(.trailing, 10)
-                                Text(StringLiterals.Register.agreePrivacyTerms)
-                                    .font(.neo15)
-                                    .foregroundStyle(isPrivacyTermAgreed ? .kuText : .white)
-                                Spacer()
-                                Image(isPrivacyTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
-                                    // 버튼 잘 눌릴 수 있게 왼쪽, 위아래로 패딩을 줌
-                                    .padding(.leading, 15)
-                                    .padding(.vertical, 6)
-                                    .onTapGesture {
-                                        // TermsView 보여줌
-                                        isPrivacyTermsViewPresented = true
-                                    }
-                                
-                            }
-                            .padding(20)
+                Image(isPrivacyTermAgreed ? .longButtonBlue : .longButtonGray)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        HStack {
+                            Image(isPrivacyTermAgreed ? .blackCheck : .whiteCheck)
+                                .padding(.trailing, 10)
+                            Text(StringLiterals.Register.agreePrivacyTerms)
+                                .font(.neo15)
+                                .foregroundStyle(isPrivacyTermAgreed ? .kuText : .white)
+                            Spacer()
+                            Image(isPrivacyTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
+                                // 버튼 잘 눌릴 수 있게 왼쪽, 위아래로 패딩을 줌
+                                .padding(.leading, 15)
+                                .padding(.vertical, 6)
+                                .onTapGesture {
+                                    // TermsView 보여줌
+                                    isPrivacyTermsViewPresented = true
+                                }
+                            
                         }
-                }
-                .buttonStyle(PlainButtonStyle())
+                        .padding(20)
+                    }
+                    .onTapGesture {
+                        withAnimation(.spring(duration: 0.2)) {
+                            isPrivacyTermAgreed.toggle()
+                        }
+                    }
                 
                 // 위치기반 서비스 이용약관 동의
-                Button {
-                    isLocationTermAgreed.toggle()
-                } label: {
-                    Image(isLocationTermAgreed ? .longButtonBlue : .longButtonGray)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            HStack {
-                                Image(isLocationTermAgreed ? .blackCheck : .whiteCheck)
-                                    .padding(.trailing, 10)
-                                Text(StringLiterals.Register.agreeLocationTerms)
-                                    .font(.neo15)
-                                    .foregroundStyle(isLocationTermAgreed ? .kuText : .white)
-                                Spacer()
-                                Image(isLocationTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
-                                    // 버튼 잘 눌릴 수 있게 왼쪽, 위아래로 패딩을 줌
-                                    .padding(.leading, 15)
-                                    .padding(.vertical, 6)
-                                    .onTapGesture {
-                                        // TermsView 보여줌
-                                        isLocationTermsViewPresented = true
-                                    }
-                            }
-                            .padding(20)
+                Image(isLocationTermAgreed ? .longButtonBlue : .longButtonGray)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        HStack {
+                            Image(isLocationTermAgreed ? .blackCheck : .whiteCheck)
+                                .padding(.trailing, 10)
+                            Text(StringLiterals.Register.agreeLocationTerms)
+                                .font(.neo15)
+                                .foregroundStyle(isLocationTermAgreed ? .kuText : .white)
+                            Spacer()
+                            Image(isLocationTermAgreed ? .rightBlackArrow : .rightWhiteArrow)
+                                // 버튼 잘 눌릴 수 있게 왼쪽, 위아래로 패딩을 줌
+                                .padding(.leading, 15)
+                                .padding(.vertical, 6)
+                                .onTapGesture {
+                                    // TermsView 보여줌
+                                    isLocationTermsViewPresented = true
+                                }
                         }
-                }
-                .buttonStyle(PlainButtonStyle())
+                        .padding(20)
+                    }
+                    .onTapGesture {
+                        withAnimation(.spring(duration: 0.2)) {
+                            isLocationTermAgreed.toggle()
+                        }
+                    }
                 
                 Spacer()
                 
-                Button {
-                    
-                } label: {
-                    Image(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .longButtonBlue : .longButtonGray)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: .infinity)
-                        .overlay {
-                            Text(StringLiterals.Register.next)
-                                .font(.neo15)
-                                .foregroundStyle(.kuText)
-                        }
-                }
-                .buttonStyle(PlainButtonStyle())
+                // 다음 버튼
+                Image(isServiceTermAgreed && isPrivacyTermAgreed && isLocationTermAgreed ? .longButtonBlue : .longButtonGray)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: .infinity)
+                    .overlay {
+                        Text(StringLiterals.Register.next)
+                            .font(.neo15)
+                            .foregroundStyle(.kuText)
+                    }
+                    .onTapGesture {
+                        // TODO: 다음 버튼 눌렀을 때 구현
+                    }
             }
             .padding(.horizontal)
             .padding(.top, 30)


### PR DESCRIPTION
### 🐣Issue
#21
<br/>

### 🐣Motivation
회원가입 관련 뷰 내 버튼 구현 방식 수정
<br/>

### 🐣Key Changes
- `RegisterTermsView` 약관 버튼 4개, 다음 버튼 1개
- `RegisterMajorView` 다음 버튼 1개
- `RegisterNicknameView` 다음 버튼 1개
- 회원가입 관련 뷰의 Neo 폰트 텍스트에 자간(kerning) 적용
<br/>

**기존 코드**
```swift
Button {
    // ...
} label: {
    Image()
        .overlay {
            Text()
        }
}
```
<br/>

**변경 코드**
```swift
Image()
    .overlay {
        Text()
    }
    .onTapGesture {
        // ...
    }
```
- 위 코드로 구현 시 버튼에서 애니메이션이 제거됨
<br/>

### 🐣To Reviewer
이전 회의에서 말했던 것처럼 이미지 버튼들의 구현 방식을 수정했습니다!
<br/>