### PR TITLE
[Fix] #47 - StringLiterals merge시 발생한 중괄호 mismatch 오류 수정

### DIFF
--- a/playkuround-iOS/Resources/StringLiterals.swift
+++ b/playkuround-iOS/Resources/StringLiterals.swift
@@ -72,6 +72,7 @@ enum StringLiterals {
         static let description2 = "게임 플레이를 위해서는\n사용자분의 위치 정보가 필요해요."
         static let description3 = "설정에서 위치 권한 허용 후\n플레이쿠라운드를 마음껏 즐겨주세요!"
         static let openSetting = "설정으로 이동"
+    }
 
     enum MyPage {
         static let currentScore = "현재 점수"


### PR DESCRIPTION
### 🐣Issue
closed #47 
<br/>

### 🐣Motivation
#45 branch merge시 발생한 conflict로 StringLiterals 파일에 중괄호가 삭제된 문제 수정
<br/>

### 🐣Key Changes
StringLiterals.swift 파일 내 75번째 줄에 닫는 중괄호(`}`)를 추가했습니다
<br/>

```swift
// ....
enum Permission {
    static let title = "위치 권한 허용하면\n플쿠 즐길 준비 완료!"
    static let description1 = "플레이쿠라운드는 GPS를 활용하여\n건국대학교를 탐험하는 게임이에요!"
    static let descriptionBold = "GPS를 활용"
    static let description2 = "게임 플레이를 위해서는\n사용자분의 위치 정보가 필요해요."
    static let description3 = "설정에서 위치 권한 허용 후\n플레이쿠라운드를 마음껏 즐겨주세요!"
    static let openSetting = "설정으로 이동"
// 아래 중괄호가 없어서 오류가 발생
}

enum MyPage {
    static let currentScore = "현재 점수"
// ....
```
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
Merge 할 때 잘못 선택했던 것 같네요. 번거롭게 해드려 죄송합니다ㅠ
<br/>

### 🐣Reference
X
<br/>
