### PR TITLE
[Setting] #52 - Landmark 데이터 추가 및 랜드마크 API 작업

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C31576C2BB7CCC000F270F7 /* Landmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31576B2BB7CCC000F270F7 /* Landmark.swift */; };
 		0C5979B52BAB215300E8156D /* RegisterMajorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979B42BAB215300E8156D /* RegisterMajorView.swift */; };
 		0C5979B82BAB25EE00E8156D /* service.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C5979B72BAB25EE00E8156D /* service.txt */; };
 		0C5979BC2BAB26A800E8156D /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979BB2BAB26A800E8156D /* TermsView.swift */; };
@@ -23,10 +24,10 @@
 		0C7FE6992BB1259800D94162 /* NetworkErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7FE6982BB1259800D94162 /* NetworkErrorView.swift */; };
 		0C7FE69B2BB1290A00D94162 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7FE69A2BB1290A00D94162 /* LoadingView.swift */; };
 		0C7FE6A12BB1983A00D94162 /* AnimationImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7FE6A02BB1983A00D94162 /* AnimationImages.swift */; };
-		0CA4C5662BB3281F00268B07 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4C5652BB3281F00268B07 /* RootView.swift */; };
-		0CB465AE2BB3D1C700317455 /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB465AD2BB3D1C700317455 /* RootViewModel.swift */; };
 		0CA193562BB5ABEB007C04B1 /* RequestPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA193552BB5ABEB007C04B1 /* RequestPermissionView.swift */; };
 		0CA193592BB5B49A007C04B1 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0CA193582BB5B49A007C04B1 /* Pretendard-Bold.otf */; };
+		0CA4C5662BB3281F00268B07 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4C5652BB3281F00268B07 /* RootView.swift */; };
+		0CB465AE2BB3D1C700317455 /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB465AD2BB3D1C700317455 /* RootViewModel.swift */; };
 		0CBB05902BB07A1400EB56BE /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB058F2BB07A1400EB56BE /* MapViewModel.swift */; };
 		0CD06A292BAB459500845B24 /* RegisterTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD06A282BAB459500845B24 /* RegisterTermsView.swift */; };
 		C914E9E32BA57DEB00161AB7 /* AnimationCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C914E9E22BA57DEB00161AB7 /* AnimationCustomView.swift */; };
@@ -79,6 +80,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0C31576B2BB7CCC000F270F7 /* Landmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Landmark.swift; sourceTree = "<group>"; };
 		0C5979B42BAB215300E8156D /* RegisterMajorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterMajorView.swift; sourceTree = "<group>"; };
 		0C5979B72BAB25EE00E8156D /* service.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = service.txt; sourceTree = "<group>"; };
 		0C5979BB2BAB26A800E8156D /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
@@ -95,10 +97,10 @@
 		0C7FE6982BB1259800D94162 /* NetworkErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorView.swift; sourceTree = "<group>"; };
 		0C7FE69A2BB1290A00D94162 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		0C7FE6A02BB1983A00D94162 /* AnimationImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationImages.swift; sourceTree = "<group>"; };
-		0CA4C5652BB3281F00268B07 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		0CB465AD2BB3D1C700317455 /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
 		0CA193552BB5ABEB007C04B1 /* RequestPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestPermissionView.swift; sourceTree = "<group>"; };
 		0CA193582BB5B49A007C04B1 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
+		0CA4C5652BB3281F00268B07 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		0CB465AD2BB3D1C700317455 /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
 		0CBB058F2BB07A1400EB56BE /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		0CD06A282BAB459500845B24 /* RegisterTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterTermsView.swift; sourceTree = "<group>"; };
 		C914E9E22BA57DEB00161AB7 /* AnimationCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCustomView.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				0C6AA4CA2BA56B510032AB24 /* Major.swift */,
 				0C6AA4CC2BA56E230032AB24 /* UserNotification.swift */,
 				0C6AA4CE2BA56FB30032AB24 /* ScoreType.swift */,
+				0C31576B2BB7CCC000F270F7 /* Landmark.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -581,6 +584,7 @@
 				C953D2F92BA47B4B00318869 /* Font.swift in Sources */,
 				0C6AA4BD2BA553D80032AB24 /* APIManager.swift in Sources */,
 				0C6AA4CB2BA56B510032AB24 /* Major.swift in Sources */,
+				0C31576C2BB7CCC000F270F7 /* Landmark.swift in Sources */,
 				0CB465AE2BB3D1C700317455 /* RootViewModel.swift in Sources */,
 				0C6396E82BAB4BB8008E046F /* RegisterNickname.swift in Sources */,
 				C97543F02BB31CEC00CD6479 /* MyPageView.swift in Sources */,

--- a/playkuround-iOS/Models/Landmark.swift
+++ b/playkuround-iOS/Models/Landmark.swift
@@ -20,6 +20,8 @@ struct Landmark: Identifiable, Codable, Equatable {
 }
 
 let landmarkList: [Landmark] = [
+    // 서버 API 반환값 및 랜드마크 인덱스는 1부터 시작하므로 0번째는 더미 노드 추가
+    Landmark(number: 0, name: "Error: Index Out of Range", latitude: 0, longitude: 0, radius: 0),
     Landmark(number: 1, name: "산학협동관", latitude: 37.539765, longitude: 127.073215, radius: 40),
     Landmark(number: 2, name: "입학정보관", latitude: 37.540296, longitude: 127.073410, radius: 20),
     Landmark(number: 3, name: "수의학관", latitude: 37.539310, longitude: 127.074590, radius: 35),

--- a/playkuround-iOS/Models/Landmark.swift
+++ b/playkuround-iOS/Models/Landmark.swift
@@ -1,0 +1,67 @@
+//
+//  Landmark.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 3/30/24.
+//
+
+import Foundation
+import SwiftUI
+import MapKit
+import CoreLocation
+
+struct Landmark: Identifiable, Codable, Equatable {
+    var id = UUID()
+    let number: Int
+    let name: String
+    let latitude: Double
+    let longitude: Double
+    let radius: Double
+}
+
+let landmarkList: [Landmark] = [
+    Landmark(number: 1, name: "산학협동관", latitude: 37.539765, longitude: 127.073215, radius: 40),
+    Landmark(number: 2, name: "입학정보관", latitude: 37.540296, longitude: 127.073410, radius: 20),
+    Landmark(number: 3, name: "수의학관", latitude: 37.539310, longitude: 127.074590, radius: 35),
+    Landmark(number: 4, name: "동물생명과학관", latitude: 37.540184, longitude: 127.074179, radius: 30),
+    Landmark(number: 5, name: "생명과학관", latitude: 37.540901, longitude: 127.074055, radius: 40),
+    Landmark(number: 6, name: "상허도서관", latitude: 37.542051, longitude: 127.073808, radius: 55),
+    Landmark(number: 7, name: "의생명과학연구관", latitude: 37.541461, longitude: 127.072215, radius: 36),
+    Landmark(number: 8, name: "예디대", latitude: 37.542908, longitude: 127.072815, radius: 50),
+    Landmark(number: 9, name: "언어교육원", latitude: 37.542533, longitude: 127.074700, radius: 35),
+    Landmark(number: 10, name: "법학관", latitude: 37.541667, longitude: 127.075046, radius: 50),
+    Landmark(number: 11, name: "상허박물관", latitude: 37.542375, longitude: 127.075711, radius: 30),
+    Landmark(number: 12, name: "행정관", latitude: 37.543222, longitude: 127.075305, radius: 44),
+    Landmark(number: 13, name: "교육과학관(사범대)", latitude: 37.543998, longitude: 127.074145, radius: 50),
+    Landmark(number: 14, name: "상허연구관", latitude: 37.544018, longitude: 127.075141, radius: 35),
+    Landmark(number: 15, name: "경영관", latitude: 37.544319, longitude: 127.076184, radius: 40),
+    Landmark(number: 16, name: "새천년관", latitude: 37.543374, longitude: 127.077314, radius: 40),
+    Landmark(number: 17, name: "건축관", latitude: 37.543732, longitude: 127.078482, radius: 25),
+    Landmark(number: 18, name: "부동산학관", latitude: 37.543283, longitude: 127.078093, radius: 25),
+    Landmark(number: 19, name: "인문학관(인문대)", latitude: 37.542602, longitude: 127.078250, radius: 40),
+    Landmark(number: 20, name: "학생회관", latitude: 37.541954, longitude: 127.077748, radius: 30),
+    Landmark(number: 21, name: "제2학생회관 & 노천극장", latitude: 37.541298, longitude: 127.077828, radius: 35),
+    Landmark(number: 22, name: "공학관 A", latitude: 37.541655, longitude: 127.078769, radius: 33),
+    Landmark(number: 23, name: "공학관 B", latitude: 37.542004, longitude: 127.079563, radius: 33),
+    Landmark(number: 24, name: "공학관 C", latitude: 37.541226, longitude: 127.079357, radius: 28),
+    Landmark(number: 25, name: "신공학관", latitude: 37.540455, longitude: 127.079304, radius: 40),
+    Landmark(number: 26, name: "과학관(이과대)", latitude: 37.541491, longitude: 127.080565, radius: 43),
+    Landmark(number: 27, name: "창의관", latitude: 37.541114, longitude: 127.081743, radius: 45),
+    Landmark(number: 28, name: "공예관", latitude: 37.542220, longitude: 127.080961, radius: 33),
+    Landmark(number: 29, name: "국제학사", latitude: 37.539995, longitude: 127.077180, radius: 40),
+    Landmark(number: 30, name: "기숙사", latitude: 37.539147, longitude: 127.078248, radius: 75),
+    Landmark(number: 31, name: "일감호", latitude: 37.530744, longitude: 127.075539, radius: 44),
+    Landmark(number: 32, name: "홍예교", latitude: 37.541688, longitude: 127.077344, radius: 18),
+    Landmark(number: 33, name: "황소동상", latitude: 37.543135, longitude: 127.076172, radius: 20),
+    Landmark(number: 34, name: "청심대", latitude: 37.542366, longitude: 127.076835, radius: 30),
+    Landmark(number: 35, name: "상허박사 동상", latitude: 37.541365, longitude: 127.073457, radius: 25),
+    Landmark(number: 36, name: "노천극장 중앙", latitude: 0, longitude: 0, radius: 0), // 제2학생회관과 합병
+    Landmark(number: 37, name: "운동장", latitude: 37.544387, longitude: 127.077593, radius: 65),
+    Landmark(number: 38, name: "실내체육관", latitude: 37.544456, longitude: 127.079587, radius: 50),
+    Landmark(number: 39, name: "건국문(후문)", latitude: 37.545122, longitude: 127.076613, radius: 20),
+    Landmark(number: 40, name: "중문", latitude: 37.541827, longitude: 127.071780, radius: 15),
+    Landmark(number: 41, name: "일감문(동물병원)", latitude: 37.539165, longitude: 127.074042, radius: 15),
+    Landmark(number: 42, name: "상허문(도서관)", latitude: 37.539692, longitude: 127.072491, radius: 25),
+    Landmark(number: 43, name: "구의역쪽문", latitude: 37.541584, longitude: 127.082226, radius: 15),
+    Landmark(number: 44, name: "기숙사쪽문", latitude: 37.539255, longitude: 127.076741, radius: 20)
+]

--- a/playkuround-iOS/Models/Landmark.swift
+++ b/playkuround-iOS/Models/Landmark.swift
@@ -6,9 +6,6 @@
 //
 
 import Foundation
-import SwiftUI
-import MapKit
-import CoreLocation
 
 struct Landmark: Identifiable, Codable, Equatable {
     var id = UUID()

--- a/playkuround-iOS/ViewModels/MapViewModel.swift
+++ b/playkuround-iOS/ViewModels/MapViewModel.swift
@@ -108,7 +108,9 @@ final class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate 
     
     // 사용자 랜드마크 업데이트
     func updateLandmark() {
-        APIManager.callGETAPI(endpoint: .landmarks, querys: ["latitude": userLatitude, "longitude": userLongitude]) { result in
+        APIManager.callGETAPI(endpoint: .landmarks,
+                              querys: ["latitude": userLatitude,
+                                       "longitude": userLongitude]) { result in
             switch result {
             case .success(let data):
                 if let response = data as? APIResponse {
@@ -144,7 +146,7 @@ struct MapViewTestView: View {
                 // 위치 권한 체크, 권한 없는 경우 요청
                 vm.requestLocationAuthorization()
             }
-             .buttonStyle(.borderedProminent)
+            .buttonStyle(.borderedProminent)
             
             Button("업데이트 시작") {
                 vm.startUpdatingLocation()


### PR DESCRIPTION
### 🐣Issue
closed #52 
<br/>

### 🐣Motivation
Landmark 데이터 구조화 및 랜드마크 API 작업을 합니다
<br/>

### 🐣Key Changes
- Landmark 데이터를 구조화하고, `landmarkList` 리스트로 선언해두었습니다
- `MapViewModel`에 `@Published userLandmarkID` 변수를 추가해두었고, 사용자의 근처 랜드마크를 저장합니다 (없으면 `nil`)
- `updateLandmark()` 함수를 호출하여 사용자와 가장 가까운 랜드마크를 업데이트합니다
<br/>

**`struct Landmark`**
```swift
struct Landmark: Identifiable, Codable, Equatable {
    var id = UUID()
    let number: Int
    let name: String
    let latitude: Double
    let longitude: Double
    let radius: Double
}

let landmarkList: [Landmark] = [
    // 서버 API 반환값 및 랜드마크 인덱스는 1부터 시작하므로 0번째는 더미 노드 추가
    Landmark(number: 0, name: "Error: Index Out of Range", latitude: 0, longitude: 0, radius: 0),
    Landmark(number: 1, name: "산학협동관", latitude: 37.539765, longitude: 127.073215, radius: 40),
    Landmark(number: 2, name: "입학정보관", latitude: 37.540296, longitude: 127.073410, radius: 20),
    // ....
```
- 서버에서 랜드마크 ID를 기획서에 맞추어 1부터 사용하므로, 호출 시마다 `landmarkList[index - 1]`를 호출하는 것보다, 0번째 인덱스에 더미 노드를 추가해서 `landmarkList[index]`를 호출하여 사용할 수 있도록 함
<br/>

**`MapViewModel` 변경사항**
```swift
// 사용자의 랜드마크
@Published var userLandmarkID: Int?
```
- 사용자와 가장 가까운 랜드마크 ID를 저장, 없다면 nil

```swift
// 필요할 때마다 랜드마크 업데이트 호출
vm.updateLandmark()

// 랜드마크가 없다면 nil이므로 safe unwrapping
if let landmarkID = vm.userLandmarkID {
    // 인덱스는 1부터 시작하며, 0번째는 더미 노드가 있으므로 인덱스를 그래도 사용 가능
    let landmark = landmarkList[landmarkID]
    Text("근처 랜드마크: \(landmark.name)(\(landmark.number))")
} else {
    Text("근처 랜드마크: 없음(nil)")
}
```
- 홈에서 탐험하기 버튼 누를 때, 위 함수를 호출해서 가장 가까운 랜드마크를 변수에 업데이트하면 됩니다
- 다른 뷰에서는 `MapViewModel.userLandmarkID`를 통해 가장 가까운 랜드마크 인덱스를 얻을 수 있습니다
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
`GameViewModel`을 만들다보니 Landmark 데이터를 사용해야 해서 추가했습니다.
원래는 json 파일로 만들어두고, json을 파싱해서 리스트를 만드려했으나, 변경될 일이 없어 다른 데이터처럼 하드코딩해두었습니다
더 효율적이거나 좋은 방법이 있다면 알려주세요!!
<br/>

### 🐣Reference
X
<br/>
