### PR TITLE
[Feat] #64 - 10초를 맞춰봐 게임 구현

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		0C5979B82BAB25EE00E8156D /* service.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C5979B72BAB25EE00E8156D /* service.txt */; };
 		0C5979BC2BAB26A800E8156D /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979BB2BAB26A800E8156D /* TermsView.swift */; };
 		0C6396E82BAB4BB8008E046F /* RegisterNickname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6396E72BAB4BB8008E046F /* RegisterNickname.swift */; };
+		0C691EB12BBD9FF2004021F1 /* TimerGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */; };
+		0C691EB32BBDA028004021F1 /* TimerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C691EB22BBDA028004021F1 /* TimerState.swift */; };
 		0C6AA4BB2BA4A33E0032AB24 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6AA4BA2BA4A33E0032AB24 /* NetworkManager.swift */; };
 		0C6AA4BD2BA553D80032AB24 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6AA4BC2BA553D80032AB24 /* APIManager.swift */; };
 		0C6AA4C72BA566CE0032AB24 /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6AA4C62BA566CE0032AB24 /* Badge.swift */; };
@@ -101,6 +103,8 @@
 		0C5979B72BAB25EE00E8156D /* service.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = service.txt; sourceTree = "<group>"; };
 		0C5979BB2BAB26A800E8156D /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
 		0C6396E72BAB4BB8008E046F /* RegisterNickname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNickname.swift; sourceTree = "<group>"; };
+		0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerGameViewModel.swift; sourceTree = "<group>"; };
+		0C691EB22BBDA028004021F1 /* TimerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerState.swift; sourceTree = "<group>"; };
 		0C6AA4BA2BA4A33E0032AB24 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		0C6AA4BC2BA553D80032AB24 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		0C6AA4C62BA566CE0032AB24 /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
@@ -297,6 +301,8 @@
 			isa = PBXGroup;
 			children = (
 				0CB902232BB6E77200F76311 /* TimerGameView.swift */,
+				0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */,
+				0C691EB22BBDA028004021F1 /* TimerState.swift */,
 			);
 			path = TimerGame;
 			sourceTree = "<group>";
@@ -675,7 +681,9 @@
 				C953D2F92BA47B4B00318869 /* Font.swift in Sources */,
 				0C6AA4BD2BA553D80032AB24 /* APIManager.swift in Sources */,
 				0C6AA4CB2BA56B510032AB24 /* Major.swift in Sources */,
+				0C691EB32BBDA028004021F1 /* TimerState.swift in Sources */,
 				0C519D9C2BBAFD9D00DAA206 /* Card.swift in Sources */,
+				0C691EB12BBD9FF2004021F1 /* TimerGameViewModel.swift in Sources */,
 				0C31576C2BB7CCC000F270F7 /* Landmark.swift in Sources */,
 				0CB465AE2BB3D1C700317455 /* RootViewModel.swift in Sources */,
 				0C6396E82BAB4BB8008E046F /* RegisterNickname.swift in Sources */,

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -77,4 +77,5 @@ enum ViewType {
     
     // Games
     case cardGame
+    case timeGame
 }

--- a/playkuround-iOS/Views/Games/TimerGame/TimerGameView.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerGameView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TimerGameView: View {
-    @State private var isPaused: Bool = false
+    @ObservedObject var viewModel: TimerGameViewModel
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -37,7 +37,7 @@ struct TimerGameView: View {
                     },
                     rightView: {
                         Button {
-                            // TODO: 일시정지
+                            viewModel.togglePauseView()
                         } label: {
                             Image(.bluePauseButton)
                         }
@@ -52,41 +52,94 @@ struct TimerGameView: View {
                         .frame(maxWidth: .infinity)
                         .offset(y: 100)
                         .overlay {
-                            VStack {
-                                Text("00:00")
+                            VStack(spacing: 0) {
+                                // 타이머
+                                Text("\(viewModel.second):\(viewModel.milliSecond)")
                                     .font(.neo70)
                                     .kerning(-0.41)
-                                    .foregroundStyle(.kuText)
+                                    .foregroundStyle(viewModel.timerState == .failed ? .kuRed : (viewModel.timerState == .success || viewModel.timerState == .perfect) ? .kuGreen : .kuText)
+                                    .onReceive(viewModel.timer) { _ in
+                                        if viewModel.timerState == .running {
+                                            viewModel.updateTimer()
+                                            viewModel.updateMilliSecondString()
+                                        }
+                                    }
                                 
-                                Text(StringLiterals.Game.Time.success)
-                                    .font(.pretendard15R)
-                                    .foregroundStyle(.kuGreen)
-                                
-                                Button {
-                                    
-                                } label: {
-                                    Image(.timeStopButton)
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: 120, height: 120)
-                                        .padding(.top, 20)
+                                // 텍스트
+                                HStack {
+                                    if viewModel.timerState == .success || viewModel.timerState == .perfect {
+                                        Text(viewModel.timerState == .failed ? StringLiterals.Game.Time.failure :  StringLiterals.Game.Time.success)
+                                            .font(.pretendard15R)
+                                            .foregroundStyle(viewModel.timerState == .failed ? .kuRed : .kuGreen)
+                                    } else if viewModel.timerState == .failed {
+                                        Text(viewModel.timerState == .failed ? StringLiterals.Game.Time.failure :  StringLiterals.Game.Time.success)
+                                            .font(.pretendard15R)
+                                            .foregroundStyle(viewModel.timerState == .failed ? .kuRed : .kuGreen)
+                                    } else {
+                                        // Spacer()
+                                    }
                                 }
+                                .frame(height: 20)
+                                .padding(.vertical, 0)
                                 
-                                // 성공 시
-                                /* AnimationCustomView(
-                                    imageArray: gameSuccessImage.allCases.map { $0.rawValue },
-                                    delayTime: 0.2)
-                                .scaledToFit()
-                                .frame(height: 140) */
+                                // 버튼
+                                if viewModel.timerState == .perfect || viewModel.timerState == .success {
+                                    AnimationCustomView(
+                                        imageArray: gameSuccessImage.allCases.map { $0.rawValue },
+                                        delayTime: 0.2)
+                                    .scaledToFit()
+                                    .frame(height: 140)
+                                } else if viewModel.timerState == .failed {
+                                    Button {
+                                        viewModel.timeButtonClick()
+                                    } label: {
+                                        Image(.timeRestartButton)
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 120, height: 120)
+                                            .padding(.top, 20)
+                                    }
+                                } else if viewModel.timerState == .running {
+                                    Button {
+                                        viewModel.timeButtonClick()
+                                    } label: {
+                                        Image(.timeStopButton)
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 120, height: 120)
+                                            .padding(.top, 20)
+                                    }
+                                } else if viewModel.timerState == .ready {
+                                    Button {
+                                        viewModel.timeButtonClick()
+                                    } label: {
+                                        Image(.timePlayButton)
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 120, height: 120)
+                                            .padding(.top, 20)
+                                    }
+                                }
                             }
                             .offset(y: 110)
                         }
                 }
+                
+                if viewModel.isCountdownViewPresented {
+                    CountdownView(countdown: $viewModel.countdown)
+                } else if viewModel.isPauseViewPresented {
+                    GamePauseView(viewModel: viewModel)
+                } else if viewModel.isResultViewPresented {
+                    GameResultView(rootViewModel: viewModel.rootViewModel, gameViewModel: viewModel)
+                }
             }
+        }
+        .onAppear {
+            viewModel.startCountdown()
         }
     }
 }
 
 #Preview {
-    TimerGameView()
+    TimerGameView(viewModel: TimerGameViewModel(.time, rootViewModel: RootViewModel(), mapViewModel: MapViewModel(), timeStart: 0, timeEnd: .infinity, timeInterval: 0.01))
 }

--- a/playkuround-iOS/Views/Games/TimerGame/TimerGameView.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerGameView.swift
@@ -57,7 +57,10 @@ struct TimerGameView: View {
                                 Text("\(viewModel.second):\(viewModel.milliSecond)")
                                     .font(.neo70)
                                     .kerning(-0.41)
-                                    .foregroundStyle(viewModel.timerState == .failed ? .kuRed : (viewModel.timerState == .success || viewModel.timerState == .perfect) ? .kuGreen : .kuText)
+                                    .foregroundStyle(viewModel.timerState == .failed ? .kuRed
+                                                     : (viewModel.timerState == .success
+                                                        || viewModel.timerState == .perfect)
+                                                     ? .kuGreen : .kuText)
                                     .onReceive(viewModel.timer) { _ in
                                         if viewModel.timerState == .running {
                                             viewModel.updateTimer()
@@ -67,57 +70,54 @@ struct TimerGameView: View {
                                 
                                 // 텍스트
                                 HStack {
-                                    if viewModel.timerState == .success || viewModel.timerState == .perfect {
-                                        Text(viewModel.timerState == .failed ? StringLiterals.Game.Time.failure :  StringLiterals.Game.Time.success)
+                                    // 성공 시
+                                    if viewModel.timerState == .success
+                                        || viewModel.timerState == .perfect {
+                                        Text(StringLiterals.Game.Time.success)
                                             .font(.pretendard15R)
-                                            .foregroundStyle(viewModel.timerState == .failed ? .kuRed : .kuGreen)
-                                    } else if viewModel.timerState == .failed {
-                                        Text(viewModel.timerState == .failed ? StringLiterals.Game.Time.failure :  StringLiterals.Game.Time.success)
+                                            .foregroundStyle(.kuGreen)
+                                    }
+                                    // 실패 시
+                                    else if viewModel.timerState == .failed {
+                                        Text(StringLiterals.Game.Time.failure)
                                             .font(.pretendard15R)
-                                            .foregroundStyle(viewModel.timerState == .failed ? .kuRed : .kuGreen)
-                                    } else {
-                                        // Spacer()
+                                            .foregroundStyle(.kuRed)
                                     }
                                 }
                                 .frame(height: 20)
                                 .padding(.vertical, 0)
                                 
                                 // 버튼
-                                if viewModel.timerState == .perfect || viewModel.timerState == .success {
+                                if viewModel.timerState == .perfect
+                                    || viewModel.timerState == .success {
                                     AnimationCustomView(
                                         imageArray: gameSuccessImage.allCases.map { $0.rawValue },
                                         delayTime: 0.2)
                                     .scaledToFit()
                                     .frame(height: 140)
-                                } else if viewModel.timerState == .failed {
+                                } else {
                                     Button {
                                         viewModel.timeButtonClick()
                                     } label: {
-                                        Image(.timeRestartButton)
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 120, height: 120)
-                                            .padding(.top, 20)
-                                    }
-                                } else if viewModel.timerState == .running {
-                                    Button {
-                                        viewModel.timeButtonClick()
-                                    } label: {
-                                        Image(.timeStopButton)
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 120, height: 120)
-                                            .padding(.top, 20)
-                                    }
-                                } else if viewModel.timerState == .ready {
-                                    Button {
-                                        viewModel.timeButtonClick()
-                                    } label: {
-                                        Image(.timePlayButton)
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 120, height: 120)
-                                            .padding(.top, 20)
+                                        if viewModel.timerState == .failed {
+                                            Image(.timeRestartButton)
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 120, height: 120)
+                                                .padding(.top, 20)
+                                        } else if viewModel.timerState == .running {
+                                            Image(.timeStopButton)
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 120, height: 120)
+                                                .padding(.top, 20)
+                                        } else if viewModel.timerState == .ready {
+                                            Image(.timePlayButton)
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 120, height: 120)
+                                                .padding(.top, 20)
+                                        }
                                     }
                                 }
                             }
@@ -130,7 +130,8 @@ struct TimerGameView: View {
                 } else if viewModel.isPauseViewPresented {
                     GamePauseView(viewModel: viewModel)
                 } else if viewModel.isResultViewPresented {
-                    GameResultView(rootViewModel: viewModel.rootViewModel, gameViewModel: viewModel)
+                    GameResultView(rootViewModel: viewModel.rootViewModel,
+                                   gameViewModel: viewModel)
                 }
             }
         }
@@ -141,5 +142,10 @@ struct TimerGameView: View {
 }
 
 #Preview {
-    TimerGameView(viewModel: TimerGameViewModel(.time, rootViewModel: RootViewModel(), mapViewModel: MapViewModel(), timeStart: 0, timeEnd: .infinity, timeInterval: 0.01))
+    TimerGameView(viewModel: TimerGameViewModel(.time,
+                                       rootViewModel: RootViewModel(),
+                                       mapViewModel: MapViewModel(),
+                                       timeStart: 0,
+                                       timeEnd: .infinity,
+                                       timeInterval: 0.01))
 }

--- a/playkuround-iOS/Views/Games/TimerGame/TimerGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerGameViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  TimerGameViewModel.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 4/3/24.
+//
+
+import Foundation
+import SwiftUI
+
+final class TimerGameViewModel: GameViewModel {
+    @Published var milliSecond: String = "00"
+    @Published var timerState: TimerState = .ready
+    
+    final func updateMilliSecondString() {
+        self.milliSecond = String(format: "%02d", Int(timeRemaining * 100) % 100)
+    }
+    
+    func timeButtonClick() {
+        // 시작 전
+        if timerState == .ready {
+            timerState = .running
+            isTimerUpdating = true
+        }
+        // 성공 여부 체크
+        else if timerState == .running {
+            isTimerUpdating = false
+            if timeRemaining == 10.0 {
+                timerState = .perfect
+                // 점수 계산 후 finishGame 함수 호출
+                score = 500
+                finishGame()
+            } else if 9.90 <= timeRemaining && timeRemaining <= 10.10 {
+                timerState = .success
+                // 점수 계산 후 finishGame 함수 호출
+                score = 50
+                finishGame()
+            } else {
+                // 실패 처리
+                timerState = .failed
+            }
+        }
+        // 실패 시 재시도
+        else if timerState == .failed {
+            timerState = .running
+            timeRemaining = 0.0
+            isTimerUpdating = true
+        }
+    }
+    
+    override func startGame() {
+        super.startGame()
+    }
+    
+    override func finishGame() {
+        gameState = .finish
+    
+        // 3초 뒤 서버로 점수 업로드
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            super.uploadResult()
+        }
+    }
+}

--- a/playkuround-iOS/Views/Games/TimerGame/TimerGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerGameViewModel.swift
@@ -48,10 +48,6 @@ final class TimerGameViewModel: GameViewModel {
         }
     }
     
-    override func startGame() {
-        super.startGame()
-    }
-    
     override func finishGame() {
         gameState = .finish
     

--- a/playkuround-iOS/Views/Games/TimerGame/TimerState.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerState.swift
@@ -1,0 +1,14 @@
+//
+//  TimerState.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 4/3/24.
+//
+
+enum TimerState {
+    case ready
+    case running
+    case success
+    case perfect
+    case failed
+}

--- a/playkuround-iOS/Views/Root/RootView.swift
+++ b/playkuround-iOS/Views/Root/RootView.swift
@@ -37,6 +37,9 @@ struct RootView: View {
                     Button("책 뒤집기") {
                         viewModel.transition(to: .cardGame)
                     }
+                    Button("10초를 맞춰봐") {
+                        viewModel.transition(to: .timeGame)
+                    }
                 }
                 .onAppear {
                     mapViewModel.startUpdatingLocation()
@@ -49,6 +52,8 @@ struct RootView: View {
                 MyPageView(viewModel: viewModel)
             case .cardGame:
                 CardGameView(viewModel: CardGameViewModel(.book, rootViewModel: self.viewModel, mapViewModel: self.mapViewModel, timeStart: 30.0, timeEnd: 0.0, timeInterval: 0.01), rootViewModel: viewModel)
+            case .timeGame:
+                TimerGameView(viewModel: TimerGameViewModel(.time, rootViewModel: viewModel, mapViewModel: mapViewModel, timeStart: 0.0, timeEnd: .infinity, timeInterval: 0.01))
             }
             
             // network error


### PR DESCRIPTION
### 🐣Issue
closed #64 
<br/>

### 🐣Motivation
10초를 맞춰봐 게임을 구현했습니다.
<br/>

### 🐣Key Changes
`GameViewModel`을 상속받은 `TimerGameViewModel`을 구현하였고, 
기존에 개발했던 `TimerGameView`를 연결했습니다.
추가된 부분은 `TimerGameView`에 타이머 상태에 따른 분기처리,
`TimerGameViewModel`에 타이머 버튼 관련 함수, 점수 처리 등 부분만 추가되었습니다.

또한, 타이머의 상태를 구분하기 위해 아래 `TimerState`를 `TimerState.swift` 파일에 만들었습니다.
```swift
enum TimerState {
    case ready
    case running
    case success
    case perfect
    case failed
}
```

추가로, 임시 홈 화면에 10초를 맞춰봐 게임 바로가기를 추가했습니다.
<br/>

### 🐣Simulation
<video src="https://github.com/playkuround/playkuround-iOS/assets/37548919/7a009228-8788-4488-87a6-52a1331618f2" width="280px"/><br/>

### 🐣To Reviewer
안드로이드에는 게임에 성공(9.9~10.1초 맞춘 경우) 바로 화면이 어두워지며 3초 카운트다운 후 결과하면으로 넘어갑니다.
피그마 기획서를 보니 이 게임은 몇 초 후 넘어가는걸로 기획이 되어있는 것 같아 안드로이드처럼 3초 후 넘어가도록 했습니다.
(게임 종료 후 바로 결과창이 떠버리면 덕쿠가 응원봉 흔드는게 안보여서 3초정도 딜레이 후 결과창이 나오도록 했습니다. (위 영상 참고!!)
감사합니다!
<br/>

### 🐣Reference
X
<br/>
