### PR TITLE
[Feat] #68 - MOON을 점령해 게임 구현

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		C918F4092BA741F300C0BFDA /* LoginBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C918F4082BA741F300C0BFDA /* LoginBottomSheetView.swift */; };
 		C918F40B2BA7507800C0BFDA /* AuthenticationCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C918F40A2BA7507800C0BFDA /* AuthenticationCodeView.swift */; };
 		C918F40D2BA753B400C0BFDA /* AuthenticationTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C918F40C2BA753B400C0BFDA /* AuthenticationTimer.swift */; };
+		C94B563F2BBF7E9D006C8C68 /* MoonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94B563E2BBF7E9D006C8C68 /* MoonState.swift */; };
+		C94B56412BBF83EB006C8C68 /* MoonGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94B56402BBF83EB006C8C68 /* MoonGameViewModel.swift */; };
 		C9519D392BB3339C00F69974 /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9519D382BB3339C00F69974 /* NavigationBarModifier.swift */; };
 		C9519D3B2BB335EC00F69974 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9519D3A2BB335EC00F69974 /* View+.swift */; };
 		C953D2F52BA47B0700318869 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = C953D2F32BA47B0700318869 /* Pretendard-Regular.otf */; };
@@ -140,6 +142,8 @@
 		C918F4082BA741F300C0BFDA /* LoginBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginBottomSheetView.swift; sourceTree = "<group>"; };
 		C918F40A2BA7507800C0BFDA /* AuthenticationCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCodeView.swift; sourceTree = "<group>"; };
 		C918F40C2BA753B400C0BFDA /* AuthenticationTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTimer.swift; sourceTree = "<group>"; };
+		C94B563E2BBF7E9D006C8C68 /* MoonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonState.swift; sourceTree = "<group>"; };
+		C94B56402BBF83EB006C8C68 /* MoonGameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonGameViewModel.swift; sourceTree = "<group>"; };
 		C9519D382BB3339C00F69974 /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
 		C9519D3A2BB335EC00F69974 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		C953D2F32BA47B0700318869 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
@@ -410,6 +414,8 @@
 			isa = PBXGroup;
 			children = (
 				C9564D7E2BB9ADE600A869ED /* MoonGameView.swift */,
+				C94B563E2BBF7E9D006C8C68 /* MoonState.swift */,
+				C94B56402BBF83EB006C8C68 /* MoonGameViewModel.swift */,
 			);
 			path = MoonGame;
 			sourceTree = "<group>";
@@ -700,6 +706,7 @@
 				C953D3042BA49BB300318869 /* MainView.swift in Sources */,
 				C918F4052BA7149A00C0BFDA /* SoundManager.swift in Sources */,
 				C918F40B2BA7507800C0BFDA /* AuthenticationCodeView.swift in Sources */,
+				C94B563F2BBF7E9D006C8C68 /* MoonState.swift in Sources */,
 				C9F694E82BA3251A009A8762 /* playkuround_iOSApp.swift in Sources */,
 				0C5979B52BAB215300E8156D /* RegisterMajorView.swift in Sources */,
 				C9519D3B2BB335EC00F69974 /* View+.swift in Sources */,
@@ -728,6 +735,7 @@
 				0C6AA4D12BA6DA340032AB24 /* TokenManager.swift in Sources */,
 				C9DAF1F72BB712D900E03D16 /* UserEntity.swift in Sources */,
 				0C27DDF02BBD714F0049B7B8 /* CardComponent.swift in Sources */,
+				C94B56412BBF83EB006C8C68 /* MoonGameViewModel.swift in Sources */,
 				C97543F62BB325A300CD6479 /* MyPageListRowView.swift in Sources */,
 				C95F8F2C2BBAC99D00E89B50 /* QuizData.json in Sources */,
 				C918F4092BA741F300C0BFDA /* LoginBottomSheetView.swift in Sources */,

--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -280,13 +280,10 @@ class GameViewModel: ObservableObject {
     // 서버로 점수 업로드 함수
     final func uploadResult() {
         // 사용자 위치 정보
-//        let latitude = mapViewModel.userLatitude
-//        let longitude = mapViewModel.userLongitude
-        let latitude: Double = 37.54040
-        let longitude: Double = 127.07920
-        let landmarkID = 25 // 신공학관
+        let latitude = mapViewModel.userLatitude
+        let longitude = mapViewModel.userLongitude
         
-        //if let landmarkID = mapViewModel.userLandmarkID {
+        if let landmarkID = mapViewModel.userLandmarkID {
             // Adventure API 호출
             // 전송 실패하더라도 callPOSTAPI 함수 내부에서 재전송 처리
             APIManager.callPOSTAPI(endpoint: .adventures,
@@ -305,11 +302,11 @@ class GameViewModel: ObservableObject {
                     print("Error in View: \(error)")
                 }
             }
-//        } else {
-//            // 랜드마크 아이디 없는 경우
-//            // 실제 게임은 랜드마크 아이디가 부여된 경우에만 시작되므로 발생X
-//            print("Error: No Landmark ID")
-//        }
+        } else {
+            // 랜드마크 아이디 없는 경우
+            // 실제 게임은 랜드마크 아이디가 부여된 경우에만 시작되므로 발생X
+            print("Error: No Landmark ID")
+        }
     }
     
     // 사용자의 게임 최고 점수 가져오는 함수

--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -280,10 +280,13 @@ class GameViewModel: ObservableObject {
     // 서버로 점수 업로드 함수
     final func uploadResult() {
         // 사용자 위치 정보
-        let latitude = mapViewModel.userLatitude
-        let longitude = mapViewModel.userLongitude
+//        let latitude = mapViewModel.userLatitude
+//        let longitude = mapViewModel.userLongitude
+        let latitude: Double = 37.54040
+        let longitude: Double = 127.07920
+        let landmarkID = 25 // 신공학관
         
-        if let landmarkID = mapViewModel.userLandmarkID {
+        //if let landmarkID = mapViewModel.userLandmarkID {
             // Adventure API 호출
             // 전송 실패하더라도 callPOSTAPI 함수 내부에서 재전송 처리
             APIManager.callPOSTAPI(endpoint: .adventures,
@@ -302,11 +305,11 @@ class GameViewModel: ObservableObject {
                     print("Error in View: \(error)")
                 }
             }
-        } else {
-            // 랜드마크 아이디 없는 경우
-            // 실제 게임은 랜드마크 아이디가 부여된 경우에만 시작되므로 발생X
-            print("Error: No Landmark ID")
-        }
+//        } else {
+//            // 랜드마크 아이디 없는 경우
+//            // 실제 게임은 랜드마크 아이디가 부여된 경우에만 시작되므로 발생X
+//            print("Error: No Landmark ID")
+//        }
     }
     
     // 사용자의 게임 최고 점수 가져오는 함수

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -78,4 +78,5 @@ enum ViewType {
     // Games
     case cardGame
     case timeGame
+    case moonGame
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -72,13 +72,12 @@ struct MoonGameView: View {
     private func moonImage(named imageName: String, padding: Bool) -> some View {
         Image(imageName)
             .padding(.bottom, padding ? 40 : 0)
-            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
             .offset(x: shouldShake ? -3 : 3, y: 0)
             .onTapGesture {
-                self.shouldShake.toggle()
-                withAnimation {
-                    viewModel.moonClick()
+                withAnimation(Animation.easeInOut(duration: 0.1).repeatCount(4)) {
+                    self.shouldShake.toggle()
                 }
+                viewModel.moonClick()
             }
             .disabled(viewModel.moonTapped == 0)
     }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MoonGameView: View {
     @ObservedObject var viewModel: MoonGameViewModel
+    @ObservedObject var rootViewModel: RootViewModel
     @State private var shouldShake = false
     
     var body: some View {
@@ -57,6 +58,9 @@ struct MoonGameView: View {
                 if viewModel.isPauseViewPresented {
                     GamePauseView(viewModel: viewModel)
                 }
+                else if viewModel.isResultViewPresented {
+                    GameResultView(rootViewModel: rootViewModel, gameViewModel: viewModel)
+                }
             }
         }
     }
@@ -67,8 +71,8 @@ struct MoonGameView: View {
             .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
             .offset(x: shouldShake ? -3 : 3, y: 0)
             .onTapGesture {
+                self.shouldShake.toggle()
                 withAnimation {
-                    self.shouldShake.toggle()
                     viewModel.moonClick()
                 }
             }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MoonGameView: View {
+    @State private var shouldShake = false
+    
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .top) {
@@ -32,13 +34,15 @@ struct MoonGameView: View {
                     Spacer()
                 }
                 .overlay {
-                    if shouldImagePadding {
-                        Image(.moon4)
-                            .padding(.bottom, 40)
-                    }
-                    else {
-                        Image(.moon4)
-                    }
+                    Image(.moon1)
+                        .padding(.bottom, shouldImagePadding ? 40 : 0)
+                        .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
+                        .offset(x: shouldShake ? -3 : 3, y: 0)
+                        .onTapGesture {
+                            withAnimation {
+                                self.shouldShake.toggle()
+                            }
+                        }
                 }
                 .padding(.top, 70)
                 .customNavigationBar(centerView: {

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -61,6 +61,10 @@ struct MoonGameView: View {
                 else if viewModel.isResultViewPresented {
                     GameResultView(rootViewModel: rootViewModel, gameViewModel: viewModel)
                 }
+                else if viewModel.moonTapped == 0 {
+                    Color.black.opacity(0.5)
+                        .ignoresSafeArea()
+                }
             }
         }
     }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -76,5 +76,6 @@ struct MoonGameView: View {
                     viewModel.moonClick()
                 }
             }
+            .disabled(viewModel.moonTapped == 0)
     }
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct MoonGameView: View {
-    @State private var shouldShake = false
     @ObservedObject var viewModel: MoonGameViewModel
+    @State private var shouldShake = false
     
     var body: some View {
         GeometryReader { geometry in
@@ -48,13 +48,15 @@ struct MoonGameView: View {
                         .foregroundStyle(.white)
                 }, rightView: {
                     Button(action: {
-                        // TODO: 일시정지
+                        viewModel.togglePauseView()
                     }, label: {
                         Image(.yellowPauseButton)
                     })
                 }, height: 67)
                 
-                
+                if viewModel.isPauseViewPresented {
+                    GamePauseView(viewModel: viewModel)
+                }
             }
         }
     }
@@ -71,5 +73,4 @@ struct MoonGameView: View {
                 }
             }
     }
-    
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MoonGameView: View {
     @State private var shouldShake = false
+    @ObservedObject var viewModel: MoonGameViewModel
     
     var body: some View {
         GeometryReader { geometry in
@@ -26,7 +27,7 @@ struct MoonGameView: View {
                         .foregroundStyle(.white)
                         .padding(.bottom, 10)
                     
-                    Text("100")
+                    Text("\(viewModel.moonTapped)")
                         .font(.neo50)
                         .kerning(-0.41)
                         .foregroundStyle(.white)
@@ -34,15 +35,58 @@ struct MoonGameView: View {
                     Spacer()
                 }
                 .overlay {
-                    Image(.moon1)
-                        .padding(.bottom, shouldImagePadding ? 40 : 0)
-                        .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
-                        .offset(x: shouldShake ? -3 : 3, y: 0)
-                        .onTapGesture {
-                            withAnimation {
-                                self.shouldShake.toggle()
+                    if viewModel.moonState == .fullMoon {
+                        Image(.moon1)
+                            .padding(.bottom, shouldImagePadding ? 40 : 0)
+                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
+                            .offset(x: shouldShake ? -3 : 3, y: 0)
+                            .onTapGesture {
+                                withAnimation {
+                                    self.shouldShake.toggle()
+                                    viewModel.moonClick()
+                                    print("fullMoon: \(viewModel.moonTapped)")
+                                }
                             }
-                        }
+                    }
+                    else if viewModel.moonState == .cracked {
+                        Image(.moon2)
+                            .padding(.bottom, shouldImagePadding ? 40 : 0)
+                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
+                            .offset(x: shouldShake ? -3 : 3, y: 0)
+                            .onTapGesture {
+                                withAnimation {
+                                    self.shouldShake.toggle()
+                                    viewModel.moonClick()
+                                    print("cracked: \(viewModel.moonTapped)")
+                                }
+                            }
+                    }
+                    else if viewModel.moonState == .moreCracked {
+                        Image(.moon3)
+                            .padding(.bottom, shouldImagePadding ? 40 : 0)
+                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
+                            .offset(x: shouldShake ? -3 : 3, y: 0)
+                            .onTapGesture {
+                                withAnimation {
+                                    self.shouldShake.toggle()
+                                    viewModel.moonClick()
+                                    print("moreCracked: \(viewModel.moonTapped)")
+                                }
+                            }
+                    }
+                    else if viewModel.moonState == .duck {
+                        Image(.moon4)
+                            .padding(.bottom, shouldImagePadding ? 40 : 0)
+                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
+                            .offset(x: shouldShake ? -3 : 3, y: 0)
+                            .onTapGesture {
+                                withAnimation {
+                                    self.shouldShake.toggle()
+                                    viewModel.moonClick()
+                                    print("duck: \(viewModel.moonTapped)")
+                                }
+                            }
+                    }
                 }
                 .padding(.top, 70)
                 .customNavigationBar(centerView: {
@@ -63,5 +107,5 @@ struct MoonGameView: View {
 }
 
 #Preview {
-    MoonGameView()
+    MoonGameView(viewModel: MoonGameViewModel(.moon, rootViewModel: RootViewModel(), mapViewModel: MapViewModel(), timeStart: 0, timeEnd: .infinity, timeInterval: 0.01))
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift
@@ -35,57 +35,9 @@ struct MoonGameView: View {
                     Spacer()
                 }
                 .overlay {
-                    if viewModel.moonState == .fullMoon {
-                        Image(.moon1)
-                            .padding(.bottom, shouldImagePadding ? 40 : 0)
-                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
-                            .offset(x: shouldShake ? -3 : 3, y: 0)
-                            .onTapGesture {
-                                withAnimation {
-                                    self.shouldShake.toggle()
-                                    viewModel.moonClick()
-                                    print("fullMoon: \(viewModel.moonTapped)")
-                                }
-                            }
-                    }
-                    else if viewModel.moonState == .cracked {
-                        Image(.moon2)
-                            .padding(.bottom, shouldImagePadding ? 40 : 0)
-                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
-                            .offset(x: shouldShake ? -3 : 3, y: 0)
-                            .onTapGesture {
-                                withAnimation {
-                                    self.shouldShake.toggle()
-                                    viewModel.moonClick()
-                                    print("cracked: \(viewModel.moonTapped)")
-                                }
-                            }
-                    }
-                    else if viewModel.moonState == .moreCracked {
-                        Image(.moon3)
-                            .padding(.bottom, shouldImagePadding ? 40 : 0)
-                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
-                            .offset(x: shouldShake ? -3 : 3, y: 0)
-                            .onTapGesture {
-                                withAnimation {
-                                    self.shouldShake.toggle()
-                                    viewModel.moonClick()
-                                    print("moreCracked: \(viewModel.moonTapped)")
-                                }
-                            }
-                    }
-                    else if viewModel.moonState == .duck {
-                        Image(.moon4)
-                            .padding(.bottom, shouldImagePadding ? 40 : 0)
-                            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
-                            .offset(x: shouldShake ? -3 : 3, y: 0)
-                            .onTapGesture {
-                                withAnimation {
-                                    self.shouldShake.toggle()
-                                    viewModel.moonClick()
-                                    print("duck: \(viewModel.moonTapped)")
-                                }
-                            }
+                    switch viewModel.moonState {
+                    case .fullMoon, .cracked, .moreCracked, .duck:
+                        moonImage(named: viewModel.moonState.image.rawValue, padding: shouldImagePadding)
                     }
                 }
                 .padding(.top, 70)
@@ -101,11 +53,23 @@ struct MoonGameView: View {
                         Image(.yellowPauseButton)
                     })
                 }, height: 67)
+                
+                
             }
         }
     }
-}
-
-#Preview {
-    MoonGameView(viewModel: MoonGameViewModel(.moon, rootViewModel: RootViewModel(), mapViewModel: MapViewModel(), timeStart: 0, timeEnd: .infinity, timeInterval: 0.01))
+    
+    private func moonImage(named imageName: String, padding: Bool) -> some View {
+        Image(imageName)
+            .padding(.bottom, padding ? 40 : 0)
+            .animation(Animation.easeInOut(duration: 0.1).repeatCount(4), value: shouldShake)
+            .offset(x: shouldShake ? -3 : 3, y: 0)
+            .onTapGesture {
+                withAnimation {
+                    self.shouldShake.toggle()
+                    viewModel.moonClick()
+                }
+            }
+    }
+    
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
@@ -20,11 +20,12 @@ final class MoonGameViewModel: GameViewModel {
             moonState = .cracked
             moonTapped -= 1
         }
-        else if 1 <= moonTapped && moonTapped <= 51 {
+        else if 1 < moonTapped && moonTapped <= 51 {
             moonState = .moreCracked
             moonTapped -= 1
         }
-        else if moonTapped == 0 {
+        else if moonTapped == 1 {
+            moonTapped = 0
             moonState = .duck
             score = 20
             finishGame()

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
@@ -12,25 +12,31 @@ final class MoonGameViewModel: GameViewModel {
     @Published var moonTapped: Int = 100
     
     func moonClick() {
-        if moonTapped <= 100 && moonTapped >= 81 {
+        if 81 < moonTapped && moonTapped <= 100 {
             moonTapped -= 1
             moonState = .fullMoon
         }
-        else if moonTapped <= 80 && moonTapped >= 51 {
+        else if 51 < moonTapped && moonTapped <= 81 {
             moonState = .cracked
             moonTapped -= 1
         }
-        else if moonTapped <= 50 && moonTapped >= 1 {
+        else if 1 <= moonTapped && moonTapped <= 51 {
             moonState = .moreCracked
             moonTapped -= 1
         }
         else if moonTapped == 0 {
             moonState = .duck
+            score = 20
             finishGame()
         }
     }
     
     override func finishGame() {
         gameState = .finish
+        
+        // 3초 뒤 서버로 점수 업로드
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            super.uploadResult()
+        }
     }
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  MoonGameViewModel.swift
+//  playkuround-iOS
+//
+//  Created by Seoyeon Choi on 4/5/24.
+//
+
+import Foundation
+
+final class MoonGameViewModel: GameViewModel {
+    @Published var moonState: MoonState = .fullMoon
+    @Published var moonTapped: Int = 100
+    
+    func moonClick() {
+        if moonTapped <= 100 && moonTapped >= 81 {
+            moonTapped -= 1
+            moonState = .fullMoon
+        }
+        else if moonTapped <= 80 && moonTapped >= 51 {
+            moonState = .cracked
+            moonTapped -= 1
+        }
+        else if moonTapped <= 50 && moonTapped >= 1 {
+            moonState = .moreCracked
+            moonTapped -= 1
+        }
+        else if moonTapped == 0 {
+            moonState = .duck
+            finishGame()
+        }
+    }
+    
+    override func finishGame() {
+        gameState = .finish
+    }
+}

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
@@ -17,12 +17,12 @@ final class MoonGameViewModel: GameViewModel {
             moonState = .fullMoon
         }
         else if 51 < moonTapped && moonTapped <= 81 {
-            moonState = .cracked
             moonTapped -= 1
+            moonState = .cracked
         }
         else if 1 < moonTapped && moonTapped <= 51 {
-            moonState = .moreCracked
             moonTapped -= 1
+            moonState = .moreCracked
         }
         else if moonTapped == 1 {
             moonTapped = 0

--- a/playkuround-iOS/Views/Games/MoonGame/MoonState.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonState.swift
@@ -12,4 +12,20 @@ enum MoonState {
     case cracked
     case moreCracked
     case duck
+    
+    var image: MoonImage {
+        switch self {
+        case .fullMoon: return .moon1
+        case .cracked: return .moon2
+        case .moreCracked: return .moon3
+        case .duck: return .moon4
+        }
+    }
+}
+
+enum MoonImage: String {
+    case moon1
+    case moon2
+    case moon3
+    case moon4
 }

--- a/playkuround-iOS/Views/Games/MoonGame/MoonState.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonState.swift
@@ -1,0 +1,15 @@
+//
+//  MoonState.swift
+//  playkuround-iOS
+//
+//  Created by Seoyeon Choi on 4/5/24.
+//
+
+import Foundation
+
+enum MoonState {
+    case fullMoon
+    case cracked
+    case moreCracked
+    case duck
+}

--- a/playkuround-iOS/Views/Root/RootView.swift
+++ b/playkuround-iOS/Views/Root/RootView.swift
@@ -40,6 +40,9 @@ struct RootView: View {
                     Button("10초를 맞춰봐") {
                         viewModel.transition(to: .timeGame)
                     }
+                    Button("MOON을 점령해") {
+                        viewModel.transition(to: .moonGame)
+                    }
                 }
                 .onAppear {
                     mapViewModel.startUpdatingLocation()
@@ -54,6 +57,9 @@ struct RootView: View {
                 CardGameView(viewModel: CardGameViewModel(.book, rootViewModel: self.viewModel, mapViewModel: self.mapViewModel, timeStart: 30.0, timeEnd: 0.0, timeInterval: 0.01), rootViewModel: viewModel)
             case .timeGame:
                 TimerGameView(viewModel: TimerGameViewModel(.time, rootViewModel: viewModel, mapViewModel: mapViewModel, timeStart: 0.0, timeEnd: .infinity, timeInterval: 0.01))
+            case .moonGame:
+                MoonGameView(viewModel: MoonGameViewModel(.moon, rootViewModel: viewModel, mapViewModel: mapViewModel, timeStart: 0.0, timeEnd: .infinity, timeInterval: 0.01), rootViewModel: viewModel)
+                
             }
             
             // network error


### PR DESCRIPTION
### 🐣Issue
closed #68 
<br/>

### 🐣Motivation
- MOON을 점령해 게임을 구현했습니다.
<br/>

### 🐣Key Changes
- 터치 횟수에 따라 달의 이미지의 상태를 `moonState`값으로 관리할 수 있도록 했습니다.
https://github.com/playkuround/playkuround-iOS/blob/54c724df80b583a5833789a361af749af5f63f30/playkuround-iOS/Views/Games/MoonGame/MoonState.swift#L10-L31

- `moonImage`라는 함수를 사용하여 겹치는 코드를 줄일 수 있도록 했습니다.
- `moonTapped` 값이 0 이면 터치가 안되도록 `disabled modifier`를 이용하여 구현했습니다.
https://github.com/playkuround/playkuround-iOS/blob/54c724df80b583a5833789a361af749af5f63f30/playkuround-iOS/Views/Games/MoonGame/MoonGameView.swift#L72-L84
<br/>

### 🐣Simulation
https://github.com/playkuround/playkuround-iOS/assets/102604192/1a0cf86d-f68f-4a9b-b870-71f5a69e12ee


<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
