### PR TITLE
[Fix] #75 - 10초를 맞춰봐 게임 시작 카운트다운 제거

### DIFF
--- a/playkuround-iOS/Views/Games/TimerGame/TimerGameView.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerGameView.swift
@@ -125,18 +125,13 @@ struct TimerGameView: View {
                         }
                 }
                 
-                if viewModel.isCountdownViewPresented {
-                    CountdownView(countdown: $viewModel.countdown)
-                } else if viewModel.isPauseViewPresented {
+                if viewModel.isPauseViewPresented {
                     GamePauseView(viewModel: viewModel)
                 } else if viewModel.isResultViewPresented {
                     GameResultView(rootViewModel: viewModel.rootViewModel,
                                    gameViewModel: viewModel)
                 }
             }
-        }
-        .onAppear {
-            viewModel.startCountdown()
         }
     }
 }


### PR DESCRIPTION
### 🐣Issue
closed #75 
<br/>

### 🐣Motivation
10초를 맞춰봐 게임에는 3초 카운트다운이 없다는 것을 뒤늦게 알게 되어 삭제했습니다
<br/>

### 🐣Key Changes
10초를 맞춰봐 게임에서 게임 시작 전 3초 카운트다운 제거
<br/>

### 🐣Simulation
<video src="https://github.com/playkuround/playkuround-iOS/assets/37548919/88e1def7-e1c0-4597-8676-40d3319b61d9" width="280px"/> <br/>

### 🐣To Reviewer

<br/>

### 🐣Reference

<br/>
