### PR TITLE
[Fix] #79 - 건쏠지식 문제 안보이는 오류 수정

### DIFF
--- a/playkuround-iOS/Views/Games/QuizGame/QuizGameView.swift
+++ b/playkuround-iOS/Views/Games/QuizGame/QuizGameView.swift
@@ -26,65 +26,61 @@ struct QuizGameView: View {
                 VStack {
                     let quiz = quizData[viewModel.randomNumber ?? 0]
                     
-                    if let randomNumber = viewModel.randomNumber {
-                        if randomNumber >= 1 {
-                            Text(quiz.question)
-                                .font(.neo20)
-                                .kerning(-0.41)
-                                .lineSpacing(6)
-                                .foregroundStyle(.kuText)
+                    Text(quiz.question)
+                        .font(.neo20)
+                        .kerning(-0.41)
+                        .lineSpacing(6)
+                        .foregroundStyle(.kuText)
+                        .multilineTextAlignment(.center)
+                        .padding(.bottom, 20)
+                        .padding(.horizontal, 20)
+                    
+                    ForEach(quiz.options.indices, id: \.self) { index in
+                        BlockView(option: quiz.options[index],
+                                  index: index,
+                                  isCorrect: index == quiz.answer,
+                                  viewModel: viewModel,
+                                  isCorrectAnswer: $viewModel.isCorrectAnswer,
+                                  selectedIndex: $selectedIndex)
+                    }
+                    
+                    if let isCorrectAnswer = viewModel.isCorrectAnswer {
+                        //정답일 때
+                        if isCorrectAnswer {
+                            Text(StringLiterals.Game.Quiz.correct)
+                                .font(.pretendard15R)
+                                .foregroundStyle(.kuGreen)
                                 .multilineTextAlignment(.center)
-                                .padding(.bottom, 20)
-                                .padding(.horizontal, 20)
-                            
-                            ForEach(quiz.options.indices, id: \.self) { index in
-                                BlockView(option: quiz.options[index],
-                                          index: index,
-                                          isCorrect: index == quiz.answer,
-                                          viewModel: viewModel,
-                                          isCorrectAnswer: $viewModel.isCorrectAnswer,
-                                          selectedIndex: $selectedIndex)
-                            }
-                            
-                            if let isCorrectAnswer = viewModel.isCorrectAnswer {
-                                //정답일 때
-                                if isCorrectAnswer {
-                                    Text(StringLiterals.Game.Quiz.correct)
-                                        .font(.pretendard15R)
-                                        .foregroundStyle(.kuGreen)
-                                        .multilineTextAlignment(.center)
-                                        .padding(.top, 20)
-                                        .padding(.bottom, shouldImagePadding ? 0 : 25)
-                                }
-                                else {
-                                    //오답일 때
-                                    Text("\(viewModel.second).\(viewModel.milliSecond)")
-                                        .font(shouldImagePadding ? .neo45 : .neo38)
-                                        .kerning(-0.41)
-                                        .foregroundStyle(.kuText)
-                                        .padding(.vertical, shouldImagePadding ? 20 : 0)
-                                        .onReceive(viewModel.timer) { _ in
-                                            if let isCorrect = viewModel.isCorrectAnswer {
-                                                if !isCorrect && viewModel.timerState == .running {
-                                                    viewModel.updateTimer2()
-                                                    viewModel.updateMilliSecondString()
-                                                    
-                                                    if viewModel.timeRemaining < 0 {
-                                                        viewModel.checkTimerFinished()
-                                                        selectedIndex = nil
-                                                        viewModel.isCorrectAnswer = nil
-                                                    }
-                                                }
+                                .padding(.top, 20)
+                                .padding(.bottom, shouldImagePadding ? 0 : 25)
+                        }
+                        else {
+                            //오답일 때
+                            Text("\(viewModel.second).\(viewModel.milliSecond)")
+                                .font(shouldImagePadding ? .neo45 : .neo38)
+                                .kerning(-0.41)
+                                .foregroundStyle(.kuText)
+                                .padding(.vertical, shouldImagePadding ? 20 : 0)
+                                .onReceive(viewModel.timer) { _ in
+                                    if let isCorrect = viewModel.isCorrectAnswer {
+                                        if !isCorrect && viewModel.timerState == .running {
+                                            viewModel.updateTimer2()
+                                            viewModel.updateMilliSecondString()
+                                            
+                                            if viewModel.timeRemaining < 0 {
+                                                viewModel.checkTimerFinished()
+                                                selectedIndex = nil
+                                                viewModel.isCorrectAnswer = nil
                                             }
                                         }
-                                    
-                                    Text(StringLiterals.Game.Quiz.incorrect)
-                                        .font(.pretendard15R)
-                                        .foregroundStyle(.kuRed)
-                                        .multilineTextAlignment(.center)
-                                        .padding(.bottom, shouldImagePadding ? 0 : 25)
+                                    }
                                 }
-                            }
+                            
+                            Text(StringLiterals.Game.Quiz.incorrect)
+                                .font(.pretendard15R)
+                                .foregroundStyle(.kuRed)
+                                .multilineTextAlignment(.center)
+                                .padding(.bottom, shouldImagePadding ? 0 : 25)
                         }
                     }
                 }

--- a/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
@@ -16,7 +16,7 @@ final class QuizGameViewModel: GameViewModel {
     @Published var timerState: QuizTimerState = .ready
     
     func createRandomNumber(data: [Quiz]) {
-        randomNumber = Int.random(in: 0..<data.count) + 1
+        randomNumber = Int.random(in: 1..<data.count)
     }
     
     final func updateMilliSecondString() {
@@ -36,7 +36,6 @@ final class QuizGameViewModel: GameViewModel {
                     timerState = .running
                     isTimerUpdating = true
                     checkTimerFinished()
-                    
                 }
             }
         }


### PR DESCRIPTION
### 🐣Issue
closed #79 
<br/>

### 🐣Motivation
- 건쏠지식 문제 안보이는 오류 수정했습니다. 
<br/>

### 🐣Key Changes
- `QuizGameViewModel`내의 `createRandomNumber`함수에서 랜덤값 만드는 범위를 1..<data.count로 변경하여
0번째 index가 포함되지 않도록 수정했습니다. 
https://github.com/playkuround/playkuround-iOS/blob/e70f955e2245bbd3ab059e450d58fa749858cf32/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift#L18-L20
<br/>

- `QuizGameView` 내에서 `viewModel.randomNumber`가 있고, 해당 `randomNumber`값이 1 이상일 때라는 조건문을 없앴습니다. 위에서 이미 `randomNumber`를 1 이상부터 만들었기 때문에 필요없다고 판단했고, `let quiz = quizData[viewModel.randomNumber ?? 0]`를 통해 `randomNumber`가 안들어와있을때에는 인덱스가 0으로 되도록 진행되는 것으로 수정했습니다. 
<br/>

### 🐣To Reviewer
- 오류가 발견된다면 말해주세요! 🙌
<br/>

