### PR TITLE
[Fix] #95 - 책뒤집기 카트 셔플 오류 수정

### DIFF
--- a/playkuround-iOS/Views/Games/CardGame/CardGameView.swift
+++ b/playkuround-iOS/Views/Games/CardGame/CardGameView.swift
@@ -62,7 +62,6 @@ struct CardGameView: View {
                 }
             }
             .onAppear {
-                viewModel.shuffleCard()
                 viewModel.startCountdown()
             }
         }

--- a/playkuround-iOS/Views/Games/CardGame/CardGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/CardGame/CardGameViewModel.swift
@@ -30,10 +30,10 @@ final class CardGameViewModel: GameViewModel {
     private var correctCount: Int = 0
     
     override func startGame() {
+        self.shuffleCard()
+        
         super.startGame()
         super.startTimer()
-        
-        self.shuffleCard()
     }
     
     override func timerDone() {

--- a/playkuround-iOS/Views/Games/CardGame/CardGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/CardGame/CardGameViewModel.swift
@@ -32,6 +32,8 @@ final class CardGameViewModel: GameViewModel {
     override func startGame() {
         super.startGame()
         super.startTimer()
+        
+        self.shuffleCard()
     }
     
     override func timerDone() {
@@ -53,7 +55,9 @@ final class CardGameViewModel: GameViewModel {
     }
     
     func shuffleCard() {
-        cardList.shuffle()
+        DispatchQueue.main.async {
+            self.cardList.shuffle()
+        }
     }
     
     func coverToDrawing(index: Int) {


### PR DESCRIPTION
### 🐣Issue
closed #95 
<br/>

### 🐣Motivation
일부 디바이스에서 책 뒤집기 게임 시 카드가 셔플되지 않는 문제를 해결했습니다.
<br/>

### 🐣Key Changes

<br/>
`ObservedObject` 클래스에서 `@Published` 프로퍼티의 값을 변경할 때는 메인 스레드에서 변경해주어야 한다고 합니다.
따라서, 아래와 같이 수정했습니다. 

```swift
func shuffleCard() {
    // 메인 스레드 실행 보장
    DispatchQueue.main.async {
        self.cardList.shuffle()
    }
}
```
<br/>

### 🐣Simulation
제 iPhone 13 mini에서 실행 녹화 영상입니다 (기존에는 아얘 셔플이 안되었었습니다..)
<video width="280px" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/c12219c8-f88a-43df-92d1-8934975fe5aa"><br/>

<br/>

### 🐣To Reviewer
발생할 수 있는 대부분의 오류가 `@Published` 프로퍼티 값을 메인 스레드 이외의 스레드에서 변경을 시도하면 만약 그 스레드가 백그라운드 스레드이거나, 중간에 race condition 등이 발생할 수 있어 메인 스레드에서 변경됨을 보장해주어야 한다고 합니다. 또 이게 애뮬레이터나, Xcode 프리뷰에서는 잘 작동하는데 실제 디바이스에서 돌렸을 때 위 문제가 발생하여 테스트할 때는 실제 디바이스에서 돌려보고, 만약 문제가 생긴다면 위 부분을 먼저 의심해보는 것이 좋을 듯 합니다!
<br/>

### 🐣Reference

<br/>
