### PR TITLE
[Feat] #108 - HomeView 및 하위 View에 HomeViewModel 연결

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		0C27DDF02BBD714F0049B7B8 /* CardComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27DDEF2BBD714F0049B7B8 /* CardComponent.swift */; };
 		0C31576C2BB7CCC000F270F7 /* Landmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31576B2BB7CCC000F270F7 /* Landmark.swift */; };
-		0C3F4E6A2C0C44C700EE9DB6 /* LandmarkDescription.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C3F4E692C0C44C700EE9DB6 /* LandmarkDescription.json */; };
 		0C3F4E6C2C0C44D000EE9DB6 /* QuizData.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C3F4E6B2C0C44D000EE9DB6 /* QuizData.json */; };
 		0C3F4E732C0C477F00EE9DB6 /* LandmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3F4E722C0C477F00EE9DB6 /* LandmarkView.swift */; };
 		0C3F4E752C0C479700EE9DB6 /* LandmarkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3F4E742C0C479700EE9DB6 /* LandmarkDetailView.swift */; };
@@ -40,6 +39,7 @@
 		0C7FE6A12BB1983A00D94162 /* AnimationImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7FE6A02BB1983A00D94162 /* AnimationImages.swift */; };
 		0C9641E62BB874E200838DA9 /* TimerBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9641E52BB874E200838DA9 /* TimerBarView.swift */; };
 		0C9641EA2BB92D6300838DA9 /* GameResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9641E92BB92D6300838DA9 /* GameResultView.swift */; };
+		0C9C3B222C0F8DCD0094EC02 /* LandmarkDescription.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C9C3B212C0F8DCD0094EC02 /* LandmarkDescription.json */; };
 		0CA07D6F2BFDA96F00564AEB /* SurviveGameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA07D6E2BFDA96F00564AEB /* SurviveGameView.swift */; };
 		0CA07D712BFDA98400564AEB /* SurviveGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA07D702BFDA98400564AEB /* SurviveGameViewModel.swift */; };
 		0CA193562BB5ABEB007C04B1 /* RequestPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA193552BB5ABEB007C04B1 /* RequestPermissionView.swift */; };
@@ -127,7 +127,6 @@
 /* Begin PBXFileReference section */
 		0C27DDEF2BBD714F0049B7B8 /* CardComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponent.swift; sourceTree = "<group>"; };
 		0C31576B2BB7CCC000F270F7 /* Landmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Landmark.swift; sourceTree = "<group>"; };
-		0C3F4E692C0C44C700EE9DB6 /* LandmarkDescription.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = LandmarkDescription.json; path = ../../../../../LandmarkDescription.json; sourceTree = "<group>"; };
 		0C3F4E6B2C0C44D000EE9DB6 /* QuizData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = QuizData.json; path = ../../../../../../Downloads/QuizData.json; sourceTree = "<group>"; };
 		0C3F4E722C0C477F00EE9DB6 /* LandmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkView.swift; sourceTree = "<group>"; };
 		0C3F4E742C0C479700EE9DB6 /* LandmarkDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkDetailView.swift; sourceTree = "<group>"; };
@@ -158,6 +157,7 @@
 		0C7FE6A02BB1983A00D94162 /* AnimationImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationImages.swift; sourceTree = "<group>"; };
 		0C9641E52BB874E200838DA9 /* TimerBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBarView.swift; sourceTree = "<group>"; };
 		0C9641E92BB92D6300838DA9 /* GameResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultView.swift; sourceTree = "<group>"; };
+		0C9C3B212C0F8DCD0094EC02 /* LandmarkDescription.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = LandmarkDescription.json; path = "../../../../../플쿠 임시/LandmarkDescription.json"; sourceTree = "<group>"; };
 		0CA07D6E2BFDA96F00564AEB /* SurviveGameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurviveGameView.swift; sourceTree = "<group>"; };
 		0CA07D702BFDA98400564AEB /* SurviveGameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurviveGameViewModel.swift; sourceTree = "<group>"; };
 		0CA193552BB5ABEB007C04B1 /* RequestPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestPermissionView.swift; sourceTree = "<group>"; };
@@ -268,8 +268,8 @@
 		0C3F4E682C0C44AB00EE9DB6 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				0C9C3B212C0F8DCD0094EC02 /* LandmarkDescription.json */,
 				0C3F4E6B2C0C44D000EE9DB6 /* QuizData.json */,
-				0C3F4E692C0C44C700EE9DB6 /* LandmarkDescription.json */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -363,9 +363,9 @@
 		0C7FE6952BB1256300D94162 /* Root */ = {
 			isa = PBXGroup;
 			children = (
-				0C7FE6982BB1259800D94162 /* NetworkErrorView.swift */,
-				0C7FE69A2BB1290A00D94162 /* LoadingView.swift */,
 				0CA4C5652BB3281F00268B07 /* RootView.swift */,
+				0C7FE69A2BB1290A00D94162 /* LoadingView.swift */,
+				0C7FE6982BB1259800D94162 /* NetworkErrorView.swift */,
 				0CA193552BB5ABEB007C04B1 /* RequestPermissionView.swift */,
 			);
 			path = Root;
@@ -392,11 +392,11 @@
 		0CB9021F2BB6E69800F76311 /* Games */ = {
 			isa = PBXGroup;
 			children = (
+				0C519D9A2BBAECA300DAA206 /* Common */,
 				0CB9743E2BFE535A008E1399 /* CatchGame */,
 				0CA07D6D2BFDA93F00564AEB /* SurviveGame */,
 				B91059FB2BDBFEA900D6455F /* AllClickGame */,
 				B9018CF92BDB60D400BC819C /* CupidGame */,
-				0C519D9A2BBAECA300DAA206 /* Common */,
 				0C519D952BBADD5B00DAA206 /* CardGame */,
 				C95F8F332BBAE1C900E89B50 /* QuizGame */,
 				C9564D7D2BB9ADD700A869ED /* MoonGame */,
@@ -427,10 +427,10 @@
 		0CBB058E2BB07A0000EB56BE /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				0CBB058F2BB07A1400EB56BE /* MapViewModel.swift */,
 				0CB465AD2BB3D1C700317455 /* RootViewModel.swift */,
-				0C519D982BBAEB6C00DAA206 /* GameViewModel.swift */,
 				0CFFF0BD2C08EB1B00397875 /* HomeViewModel.swift */,
+				0CBB058F2BB07A1400EB56BE /* MapViewModel.swift */,
+				0C519D982BBAEB6C00DAA206 /* GameViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -438,9 +438,9 @@
 		0CD0402B2C062A14009F9BE1 /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				0C3F4E6D2C0C458300EE9DB6 /* Landmark */,
-				0CD0402C2C062A8E009F9BE1 /* AttendanceView.swift */,
 				0C7609F12C0DA9590087EA55 /* HomeView.swift */,
+				0CD0402C2C062A8E009F9BE1 /* AttendanceView.swift */,
+				0C3F4E6D2C0C458300EE9DB6 /* Landmark */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -514,8 +514,8 @@
 		C953D2FC2BA4806900318869 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				0C7C4E3D2C07A2D900ABB4D8 /* Map */,
 				0CD0402B2C062A14009F9BE1 /* Home */,
+				0C7C4E3D2C07A2D900ABB4D8 /* Map */,
 				0CB9021F2BB6E69800F76311 /* Games */,
 				C97543EE2BB31CE100CD6479 /* MyPage */,
 				0C7FE6952BB1256300D94162 /* Root */,
@@ -778,6 +778,7 @@
 				C98078A92BA871A000C04B2D /* cardClicked.mp3 in Resources */,
 				C980789C2BA8712700C04B2D /* cupidBad.mp3 in Resources */,
 				C98078B22BA8720D00C04B2D /* classEnd.mp3 in Resources */,
+				0C9C3B222C0F8DCD0094EC02 /* LandmarkDescription.json in Resources */,
 				C98078A82BA871A000C04B2D /* cardIncorrect.mp3 in Resources */,
 				C98078B12BA8720D00C04B2D /* classMinusHeart.mp3 in Resources */,
 				0C3F4E6C2C0C44D000EE9DB6 /* QuizData.json in Resources */,
@@ -787,7 +788,6 @@
 				C9F694EF2BA3251B009A8762 /* Preview Assets.xcassets in Resources */,
 				C98078BE2BA872A300C04B2D /* duckkuWindowOpenAndClose.mp3 in Resources */,
 				C98078982BA870E400C04B2D /* timerIncorrect.mp3 in Resources */,
-				0C3F4E6A2C0C44C700EE9DB6 /* LandmarkDescription.json in Resources */,
 				C98078BF2BA872A300C04B2D /* duckkuClicked.mp3 in Resources */,
 				0C6B77F62BABCC8F0033CEEF /* location.txt in Resources */,
 				C98078AA2BA871A000C04B2D /* cardCorrect.mp3 in Resources */,

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -116,12 +116,13 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
-    func attendance() {
-        APIManager.callPOSTAPI(endpoint: .attendances, parameters: ["latitude": 37.54040, "longitude": 127.07920]) { result in
+    func attendance(latitude: Double, longitude: Double) {
+        APIManager.callPOSTAPI(endpoint: .attendances, parameters: ["latitude": latitude, "longitude": longitude]) { result in
             switch result {
             case .success(_):
                 self.loadAttendance()
             case .failure(let error):
+                // TODO: 건국대학교 범위 외 혹은 다른 이유로 출석 실패 시 예외 처리 필요 (추후 APIManager 작업 시 구현)
                 print("Error in View: \(error)")
             }
         }

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -116,6 +116,17 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
+    func attendance() {
+        APIManager.callPOSTAPI(endpoint: .attendances, parameters: ["latitude": 37.54040, "longitude": 127.07920]) { result in
+            switch result {
+            case .success(_):
+                self.loadAttendance()
+            case .failure(let error):
+                print("Error in View: \(error)")
+            }
+        }
+    }
+    
     // MARK: - Total Ranking
     func loadTotalRanking() {
         APIManager.callGETAPI(endpoint: .scoresRank) { result in

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -71,10 +71,6 @@ enum ViewType {
     
     // home
     case home
-    case attendance
-    
-    // my page
-    case myPage
     
     // Games
     case cardGame

--- a/playkuround-iOS/Views/Home/AttendanceView.swift
+++ b/playkuround-iOS/Views/Home/AttendanceView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct AttendanceView: View {
     @ObservedObject var rootViewModel: RootViewModel
+    @ObservedObject var homeViewModel: HomeViewModel
     @State private var dates: [Date] = []
     
     var body: some View {

--- a/playkuround-iOS/Views/Home/AttendanceView.swift
+++ b/playkuround-iOS/Views/Home/AttendanceView.swift
@@ -57,7 +57,7 @@ struct AttendanceView: View {
                             .padding(.bottom, 32)
                             
                             Button {
-                                // TODO: 출석 처리
+                                homeViewModel.attendance()
                             } label: {
                                 // TODO: 출석 완료 시 회색 버튼
                                 Image(.shortButtonBlue)

--- a/playkuround-iOS/Views/Home/AttendanceView.swift
+++ b/playkuround-iOS/Views/Home/AttendanceView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct AttendanceView: View {
     @ObservedObject var rootViewModel: RootViewModel
     @ObservedObject var homeViewModel: HomeViewModel
+    @ObservedObject var mapViewModel: MapViewModel
     @State private var dates: [Date] = []
     
     var body: some View {
@@ -82,7 +83,7 @@ struct AttendanceView: View {
                             let isTodayAttended = checkAttended(Date())
                             
                             Button {
-                                homeViewModel.attendance()
+                                homeViewModel.attendance(latitude: mapViewModel.userLatitude, longitude: mapViewModel.userLongitude)
                             } label: {
                                 Image(isTodayAttended ? .shortButtonGray : .shortButtonBlue)
                                     .overlay {
@@ -152,5 +153,5 @@ struct AttendanceView: View {
 }
 
 #Preview {
-    AttendanceView(rootViewModel: RootViewModel(), homeViewModel: HomeViewModel())
+    AttendanceView(rootViewModel: RootViewModel(), homeViewModel: HomeViewModel(), mapViewModel: MapViewModel())
 }

--- a/playkuround-iOS/Views/Home/AttendanceView.swift
+++ b/playkuround-iOS/Views/Home/AttendanceView.swift
@@ -32,24 +32,46 @@ struct AttendanceView: View {
                                     if date.isToday() {
                                         // 오늘
                                         ZStack {
-                                            // TODO: 출석 하기 전 빈 박스, 출석 후 박스
-                                            Image(.calendarTodayBox)
-                                                .resizable()
-                                                .frame(width: 34, height: 34)
-                                            Text(date.toCalendarString())
-                                                .font(.pretendard17R)
-                                                .foregroundColor(.kuText)
-                                                .kerning(-0.41)
+                                            if checkAttended(date) {
+                                                Image(.calendarBox)
+                                                    .resizable()
+                                                    .frame(width: 34, height: 34)
+                                                Text(date.toCalendarString())
+                                                    .font(.pretendard17R)
+                                                    .foregroundColor(.kuText)
+                                                    .fontWeight(.medium)
+                                                    .kerning(-0.41)
+                                            } else {
+                                                Image(.calendarTodayBox)
+                                                    .resizable()
+                                                    .frame(width: 34, height: 34)
+                                                Text(date.toCalendarString())
+                                                    .font(.pretendard17R)
+                                                    .foregroundColor(.kuText)
+                                                    .fontWeight(.medium)
+                                                    .kerning(-0.41)
+                                            }
                                         }
                                         .frame(width: 34, height: 34)
                                     } else {
                                         // 과거
                                         ZStack {
-                                            // TODO: if 출석 했다면 박스 흰색글씨, 안했다면 박스X 회색글씨
-                                            Text(date.toCalendarString())
-                                                .font(.pretendard17R)
-                                                .foregroundColor(.kuGray2)
-                                                .kerning(-0.41)
+                                            if checkAttended(date) {
+                                                Image(.calendarBox)
+                                                    .resizable()
+                                                    .frame(width: 34, height: 34)
+                                                Text(date.toCalendarString())
+                                                    .font(.pretendard17R)
+                                                    .foregroundColor(.white)
+                                                    .fontWeight(.medium)
+                                                    .kerning(-0.41)
+                                            } else {
+                                                Text(date.toCalendarString())
+                                                    .font(.pretendard17R)
+                                                    .foregroundColor(.kuGray2)
+                                                    .fontWeight(.medium)
+                                                    .kerning(-0.41)
+                                            }
                                         }
                                         .frame(width: 34, height: 34)
                                     }
@@ -57,18 +79,20 @@ struct AttendanceView: View {
                             }
                             .padding(.bottom, 32)
                             
+                            let isTodayAttended = checkAttended(Date())
+                            
                             Button {
                                 homeViewModel.attendance()
                             } label: {
-                                // TODO: 출석 완료 시 회색 버튼
-                                Image(.shortButtonBlue)
+                                Image(isTodayAttended ? .shortButtonGray : .shortButtonBlue)
                                     .overlay {
-                                        Text(StringLiterals.Home.Attendance.attendance)
+                                        Text(isTodayAttended ? StringLiterals.Home.Attendance.attenanceDone : StringLiterals.Home.Attendance.attendance)
                                             .font(.neo18)
                                             .kerning(-0.41)
                                             .foregroundStyle(.kuText)
                                     }
                             }
+                            .disabled(isTodayAttended)
                         }
                         .offset(y: 24)
                         .padding(50)
@@ -84,7 +108,7 @@ struct AttendanceView: View {
                     .foregroundStyle(.white)
             }, leftView: {
                 Button {
-                    rootViewModel.transition(to: .home)
+                    homeViewModel.transition(to: .home)
                 } label: {
                     Image(.leftWhiteArrow)
                 }
@@ -92,12 +116,10 @@ struct AttendanceView: View {
         }
         .onAppear {
             dates = generateDates()
-            // TODO: 출석 확인 API 호출하여 날짜별 출석 여부 표시
         }
     }
     
-    // TODO: ViewModel 만들면 VM내로 옮기기
-    func generateDates() -> [Date] {
+    private func generateDates() -> [Date] {
         var calendar = Calendar.current
         calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         
@@ -117,8 +139,18 @@ struct AttendanceView: View {
         
         return dates
     }
+    
+    private func checkAttended(_ date: Date) -> Bool {
+        guard let dateString = date.toFormattedString("yyyy-MM-dd") else { return false }
+        
+        if homeViewModel.attendanceList.contains(dateString) {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 #Preview {
-    AttendanceView(rootViewModel: RootViewModel())
+    AttendanceView(rootViewModel: RootViewModel(), homeViewModel: HomeViewModel())
 }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -73,7 +73,7 @@ struct HomeView: View {
                         // TODO: 버튼 클릭 시 각 뷰 표시
                         VStack(spacing: 7) {
                             Button {
-                                // homeViewModel.transition(to: .attendance)
+                                homeViewModel.transition(to: .attendance)
                             } label: {
                                 Image(.attendanceButton)
                             }
@@ -91,7 +91,7 @@ struct HomeView: View {
                             }
                             
                             Button {
-                                // homeViewModel.transition(to: .myPage)
+                                homeViewModel.transition(to: .myPage)
                             } label: {
                                 Image(.myPageButton)
                             }
@@ -149,15 +149,15 @@ struct HomeView: View {
                 case .home:
                     EmptyView()
                 case .attendance:
-                    // AttendanceView(rootViewModel: viewModel, homeViewModel: homeViewModel)
-                    AttendanceView(rootViewModel: viewModel)
+                    AttendanceView(rootViewModel: viewModel, homeViewModel: homeViewModel)
                 case .badge:
+                    // TODO: Badge View
                     EmptyView()
                 case .ranking:
+                    // TODO: Ranking View
                     EmptyView()
                 case .myPage:
-                    // MyPageView(viewModel: viewModel, homeViewModel: homeViewModel)
-                    MyPageView(viewModel: viewModel)
+                    MyPageView(viewModel: viewModel, homeViewModel: homeViewModel)
                 case .landmark:
                     LandmarkView(homeViewModel: homeViewModel)
                 }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -17,8 +17,7 @@ struct HomeView: View {
             ZStack {
                 Color.kuDarkGreen.ignoresSafeArea(.all)
                 
-                // MapView(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
-                MapView(mapViewModel: mapViewModel)
+                MapView(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
                 
                 Image(.homeBorder)
                     .resizable()

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -149,7 +149,7 @@ struct HomeView: View {
                 case .home:
                     EmptyView()
                 case .attendance:
-                    AttendanceView(rootViewModel: viewModel, homeViewModel: homeViewModel)
+                    AttendanceView(rootViewModel: viewModel, homeViewModel: homeViewModel, mapViewModel: mapViewModel)
                 case .badge:
                     // TODO: Badge View
                     EmptyView()

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkDetailView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkDetailView.swift
@@ -60,9 +60,6 @@ struct LandmarkDetailView: View {
                     .offset(y: 44)
                 }
         }
-        .onAppear {
-            homeViewModel.selectedLandmarkID = 1
-        }
     }
     
     private func getRandomDescription() -> String {

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkView.swift
@@ -96,10 +96,6 @@ struct LandmarkView: View {
                     }
             }
         }
-        .onAppear {
-            // Test용 코드 (Merge 전 삭제 예정)
-            homeViewModel.openLandmarkView(landmarkID: 25)
-        }
     }
 }
 

--- a/playkuround-iOS/Views/Map/MapView.swift
+++ b/playkuround-iOS/Views/Map/MapView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct MapView: View {
     @ObservedObject var mapViewModel: MapViewModel
+    @ObservedObject var homeViewModel: HomeViewModel
     
     @State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 37.542_634, longitude: 127.076_769), span: MKCoordinateSpan(latitudeDelta: 0.009, longitudeDelta: 0.009))
     @State private var annotationList: [AnnotationWrapper] = []
@@ -22,8 +23,7 @@ struct MapView: View {
                     // getAnnotation(annotation)
                     CustomMapAnnotationView(annotation: annotation, mapViewModel: mapViewModel)
                         .onTapGesture {
-                            // TODO: HomeView에서 랜드마크 상세정보 표시
-                            print(annotation.landmark.name)
+                            homeViewModel.openLandmarkView(landmarkID: annotation.landmark.number)
                         }
                 }
             } else {
@@ -55,5 +55,5 @@ struct MapView: View {
 }
 
 #Preview {
-    MapView(mapViewModel: MapViewModel())
+    MapView(mapViewModel: MapViewModel(), homeViewModel: HomeViewModel())
 }

--- a/playkuround-iOS/Views/MyPage/MyPageView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageView.swift
@@ -9,9 +9,6 @@ import SwiftUI
 
 struct MyPageView: View {
     @ObservedObject var viewModel: RootViewModel
-    @State private var user: UserEntity = UserEntity(nickname:  "", major: "",
-                                                     myRank: MyRank(score: 0, ranking: 0),
-                                                     highestScore: 0, highestRank: "")
     @ObservedObject var homeViewModel: HomeViewModel
     
     @State private var isLogoutPresented: Bool = false
@@ -24,7 +21,7 @@ struct MyPageView: View {
             Color(.kuBackground).ignoresSafeArea(.all)
             
             VStack {
-                MyPageProfileView(user: user)
+                MyPageProfileView(user: homeViewModel.userData)
                 
                 Rectangle()
                     .fill(.kuBlue3)
@@ -79,7 +76,7 @@ struct MyPageView: View {
                             .foregroundStyle(.kuText)
                     }, leftView: {
                         Button(action: {
-                            viewModel.transition(to: .home)
+                            homeViewModel.transition(to: .home)
                         }, label: {
                             Image(.leftBlackArrow)
                         })
@@ -111,12 +108,12 @@ struct MyPageView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("serviceTermsViewPresented"))) { _ in
             self.isServiceTermsViewPresented = true
         }
-        .onAppear {
+        /* .onAppear {
             callGetAPIUsers()
-        }
+        }*/
     }
     
-    private func callGetAPIUsers() {
+    /* private func callGetAPIUsers() {
         APIManager.callGETAPI(endpoint: .users) { result in
             switch result {
             case .success(let data):
@@ -152,5 +149,5 @@ struct MyPageView: View {
                 print("Error in View: \(error)")
             }
         }
-    }
+    }*/
 }

--- a/playkuround-iOS/Views/MyPage/MyPageView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageView.swift
@@ -108,46 +108,5 @@ struct MyPageView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("serviceTermsViewPresented"))) { _ in
             self.isServiceTermsViewPresented = true
         }
-        /* .onAppear {
-            callGetAPIUsers()
-        }*/
     }
-    
-    /* private func callGetAPIUsers() {
-        APIManager.callGETAPI(endpoint: .users) { result in
-            switch result {
-            case .success(let data):
-                print("Data received in View: \(data)")
-                
-                if let response = data as? APIResponse {
-                    if response.isSuccess {
-                        user.nickname = response.response?.nickname ?? "-"
-                        user.major = response.response?.major ?? "-"
-                        user.highestScore = response.response?.highestScore ?? 0
-                        user.highestRank = response.response?.highestRank ?? "-"
-                    }
-                }
-                
-            case .failure(let error):
-                print("Error in View: \(error)")
-            }
-        }
-        
-        APIManager.callGETAPI(endpoint: .scoresRank) { result in
-            switch result {
-            case .success(let data):
-                print("Data received in View: \(data)")
-                
-                if let response = data as? APIResponse {
-                    if response.isSuccess {
-                        user.myRank.score = response.response?.myRank?.score ?? 0
-                        user.myRank.ranking = response.response?.myRank?.ranking ?? 0
-                    }
-                }
-                
-            case .failure(let error):
-                print("Error in View: \(error)")
-            }
-        }
-    }*/
 }

--- a/playkuround-iOS/Views/MyPage/MyPageView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageView.swift
@@ -12,6 +12,7 @@ struct MyPageView: View {
     @State private var user: UserEntity = UserEntity(nickname:  "", major: "",
                                                      myRank: MyRank(score: 0, ranking: 0),
                                                      highestScore: 0, highestRank: "")
+    @ObservedObject var homeViewModel: HomeViewModel
     
     @State private var isLogoutPresented: Bool = false
     @State private var isCheerPresented: Bool = false

--- a/playkuround-iOS/Views/Root/RootView.swift
+++ b/playkuround-iOS/Views/Root/RootView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct RootView: View {
     @ObservedObject var viewModel: RootViewModel = RootViewModel()
     @ObservedObject var mapViewModel: MapViewModel = MapViewModel()
+    @ObservedObject var homeViewModel: HomeViewModel = HomeViewModel()
     
     var body: some View {
         ZStack {
@@ -25,56 +26,7 @@ struct RootView: View {
             case .registerNickname:
                 RegisterNickname(viewModel: viewModel)
             case .home:
-                // 임시 구현
-                VStack {
-                    Text("Home")
-                    Button("출석체크") {
-                        viewModel.transition(to: .attendance)
-                    }
-                    Button("Logout") {
-                        viewModel.logout()
-                    }
-                    Button("myPage") {
-                        viewModel.transition(to: .myPage)
-                    }
-                    Button("책 뒤집기") {
-                        viewModel.transition(to: .cardGame)
-                    }
-                    Button("10초를 맞춰봐") {
-                        viewModel.transition(to: .timeGame)
-                    }
-                    Button("MOON을 점령해") {
-                        viewModel.transition(to: .moonGame)
-                    }
-                    Button("건쏠지식") {
-                        viewModel.transition(to: .quizGame)
-                    }
-                    Button("덕큐피트") {
-                        viewModel.transition(to: .cupidGame)
-                    }
-                    Button("수강신청 ALL 클릭") {
-                        viewModel.transition(to: .allClickGame)
-                    }
-                    Button("일감호에서 살아남기") {
-                        viewModel.transition(to: .surviveGame)
-                    }
-                    Button("덕쿠를 잡아라!") {
-                        viewModel.transition(to: .catchGame)
-                    }
-                }
-                .onAppear {
-                    mapViewModel.startUpdatingLocation()
-                }
-                .onDisappear {
-                    // 홈 뷰에서 벗어날 때 위치 업데이트 중지
-                    mapViewModel.stopUpdatingLocation()
-                }
-                
-            case .attendance:
-                AttendanceView(rootViewModel: viewModel)
-                
-            case .myPage:
-                MyPageView(viewModel: viewModel)
+                HomeView(viewModel: viewModel, homeViewModel: homeViewModel, mapViewModel: mapViewModel)
             case .cardGame:
                 CardGameView(viewModel: CardGameViewModel(.book, rootViewModel: self.viewModel, mapViewModel: self.mapViewModel, timeStart: 30.0, timeEnd: 0.0, timeInterval: 0.01), rootViewModel: viewModel)
             case .timeGame:


### PR DESCRIPTION
### 🐣Issue
closed #108 
<br/>

### 🐣Motivation
HomeView와 하위 View들에 HomeViewModel을 연결합니다.
<br/>

### 🐣Key Changes
- HomeView
    - HomeView 하위 뷰 (출석, 랜드마크, 마이페이지) 연결
- MapView
    - Map Annotation (깃발) 클릭 시 LandmarkView 열림
- MyPageView
    - HomeViewModel 연결 (유저 데이터)
- AttendanceView
    - 출석 기능 구현 및 HomeViewModel 연결
    - MapViewModel에서 유저 위치 가져와 출석
- RootView
    - 기존 테스트뷰 제거하고 HomeView로 전환 (기존에 게임들은 HomeView의 탐험하기 버튼 클릭 시 가능)
<br/>

**HomeView 하위 뷰 이동 시**
HomeView의 하위 뷰인 출석, 뱃지, 전체 랭킹, 마이페이지 및 랜드마크, 탐험뷰는 RootView가 아닌 HomeView 위에서 이동 구현해주시면 됩니다!
```swift
homeViewModel.transition(to: HomeStatus)

enum HomeViewType {
    case home
    case attendance // AttendanceView
    case badge // 뱃지
    case ranking // 랭킹
    case myPage // MyPageView
    
    case landmark // LandmarkView
}
```

참고로, HomeView 내 뷰 간의 전환은 배경의 0.5 투명한 검은색이 깜빡거리는 이슈가 있어 애니메이션은 일단 적용하지 않았습니다..!

<br/>

### 🐣Simulation
**출석 성공 시!**
<video width="280px" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/cda644e6-c551-447c-8cf8-7afe3092fd94">

**HomeView 전체 UI (일부 구현)**
<video width="280px" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/7b3fce45-96ca-4134-859d-34781343be2f">

전체 랭킹, 뱃지 뷰 HomeView쪽에 붙여주시면 됩니다!!

<br/>

### 🐣To Reviewer
이 PR을 마지막으로 시험 기간 이슈로 이제 당분간(대략 6/20까지) 작업이 중단될 예정입니다 
(여기까지는 지난주에 작업을 해두었고 또 뱃지뷰랑 랭킹을 붙일 때 필요할 것 같아 빠르게 올립니다..!)
리뷰나 연락은 최대한 빠르게 보겠습니다!! 파이팅입니다!
<br/>

### 🐣Reference
X
<br/>
