### PR TITLE
[Feat] #114 - BadgeView 로직 적용 및 서버 연결

### DIFF
--- a/playkuround-iOS/Models/Badge.swift
+++ b/playkuround-iOS/Models/Badge.swift
@@ -5,13 +5,6 @@
 //  Created by Hoeun Lee on 3/16/24.
 //
 
-
-//struct Badge: Identifiable {
-//    var id = UUID()
-//    let name: String
-//    let isEmpty: Bool
-//}
-
 import SwiftUI
 
 enum Badge: String, CaseIterable {

--- a/playkuround-iOS/Views/Home/Badge/BadgeDetailView.swift
+++ b/playkuround-iOS/Views/Home/Badge/BadgeDetailView.swift
@@ -9,20 +9,22 @@ import SwiftUI
 
 struct BadgeDetailView: View {
     let badge: Badge
-    @Binding var showDetail: Bool
+    let isLocked: Bool
+    
+    @Binding var showDetailBadge: Bool
     
     var body: some View {
         ZStack {
             Color.black.opacity(0.5)
                 .ignoresSafeArea()
                 .onTapGesture {
-                    showDetail.toggle()
+                    showDetailBadge.toggle()
                 }
             
             Image(.badgePopup)
                 .overlay {
                     VStack {
-                        badge.image
+                        (isLocked ? Image(.badgeLock) : badge.image)
                             .resizable()
                             .frame(width: 120, height: 120)
                             .padding(.bottom, 16)
@@ -33,7 +35,7 @@ struct BadgeDetailView: View {
                             .foregroundStyle(.kuText)
                             .padding(.bottom, 16)
                         
-                        Text(badge.description)
+                        Text(isLocked ? badge.lockDescription : badge.description)
                             .font(.pretendard15R)
                             .foregroundStyle(.kuText)
                             .lineSpacing(15 * 0.3)

--- a/playkuround-iOS/Views/Home/Badge/BadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/BadgeView.swift
@@ -20,6 +20,9 @@ struct BadgeView: View {
                 .resizable()
                 .ignoresSafeArea(.all)
             
+            Color.black.opacity(0.2)
+                .ignoresSafeArea(.all)
+            
             ScrollView {
                 VStack {
                     Image(.attendanceBadgeTable)

--- a/playkuround-iOS/Views/Home/Badge/BadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/BadgeView.swift
@@ -11,8 +11,9 @@ struct BadgeView: View {
     @ObservedObject var rootViewModel: RootViewModel
     @ObservedObject var homeViewModel: HomeViewModel
     
-    @State private var showDetail: Bool = false
+    @State private var showDetailBadge: Bool = false
     @State private var selectedBadge: Badge?
+    @State private var isSelectedBadgeLocked: Bool = false
     
     var body: some View {
         ZStack {
@@ -22,6 +23,8 @@ struct BadgeView: View {
             
             Color.black.opacity(0.2)
                 .ignoresSafeArea(.all)
+            
+            let badgeList: [BadgeResponse] = homeViewModel.badgeList
             
             ScrollView {
                 VStack {
@@ -36,13 +39,14 @@ struct BadgeView: View {
                                 
                                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 4), spacing: 10) {
                                     /// 0~10번째: 출석 뱃지
-                                    ForEach(Array(Badge.allCases.prefix(11)), id: \.self) { badge in
-                                        badge.image
+                                    ForEach(Badge.allCases.prefix(11), id: \.self) { badge in
+                                        filterBadgeImage(for: badge)
                                             .resizable()
                                             .aspectRatio(contentMode: .fit)
                                             .onTapGesture {
-                                                self.showDetail.toggle()
+                                                self.showDetailBadge.toggle()
                                                 selectedBadge = badge
+                                                isSelectedBadgeLocked = !badgeList.contains { $0.description == badge.rawValue }
                                             }
                                     }
                                 }
@@ -63,13 +67,14 @@ struct BadgeView: View {
                                 
                                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 4), spacing: 10) {
                                     /// 11~37번째: 탐험 뱃지
-                                    ForEach(Array(Badge.allCases.suffix(27)), id: \.self) { badge in
-                                        badge.image
+                                    ForEach(Badge.allCases.suffix(27), id: \.self) { badge in
+                                        filterBadgeImage(for: badge)
                                             .resizable()
                                             .aspectRatio(contentMode: .fit)
                                             .onTapGesture {
-                                                self.showDetail.toggle()
+                                                self.showDetailBadge.toggle()
                                                 selectedBadge = badge
+                                                isSelectedBadgeLocked = !badgeList.contains { $0.description == badge.rawValue }
                                             }
                                     }
                                 }
@@ -94,14 +99,23 @@ struct BadgeView: View {
                 }
             }, height: 42)
             
-            if showDetail {
+            if showDetailBadge {
                 if let selectedBadge = selectedBadge {
                     BadgeDetailView(badge: selectedBadge,
-                                    showDetail: $showDetail)
+                                    isLocked: isSelectedBadgeLocked,
+                                    showDetailBadge: $showDetailBadge)
                 }
             }
         }
         .ignoresSafeArea(edges: .bottom)
+    }
+    
+    func filterBadgeImage(for badge: Badge) -> Image {
+        if homeViewModel.badgeList.contains(where: { $0.description == badge.rawValue }) {
+            return badge.image
+        } else {
+            return Image(.badgeLock)
+        }
     }
 }
 


### PR DESCRIPTION
### 🐣Issue
closed #114 
<br/>

### 🐣Motivation
- BadgeView 서버 연결하고 로직 적용 완료했습니다.
- UI 구현 때 못했던 백그라운드 이미지에 opacity 적용했습니다. 
<br/>

### 🐣Key Changes

- 서버에서 받아온 뱃지리스트 안의 BadgeResponse.description과 Badge enum안의 rawValue가 같다면 해당 뱃지 이미지가 보이게 하고 같지 않다면 잠금 이미지가 보이도록 하는 함수 입니다. 

```swift
func filterBadgeImage(for badge: Badge) -> Image {
        if homeViewModel.badgeList.contains(where: { $0.description == badge.rawValue }) {
            return badge.image
        } else {
            return Image(.badgeLock)
        }
    }
```
<br/>

### 🐣Simulation
 <img src="https://github.com/playkuround/playkuround-iOS/assets/102604192/4c2c0f99-e600-4a01-bf5d-f491ecb80064" width=250> 

<br/>

### 🐣To Reviewer

<br/>

### 🐣Reference

<br/>
