### PR TITLE
[Feat] #127 - LandmarkRankingView 로직 구현 및 서버 연결

### DIFF
--- a/playkuround-iOS/Models/UserEntity.swift
+++ b/playkuround-iOS/Models/UserEntity.swift
@@ -10,7 +10,8 @@ import Foundation
 struct UserEntity {
     var nickname: String
     var major: String
-    var myRank: MyRank
+    var myRank: MyRank // 전체 랭킹
+    var landmarkRank: MyRank // 랜드마크별 랭킹
     var highestScore: Int
     var highestRank: String
 }

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -10,7 +10,10 @@ import SwiftUI
 
 final class HomeViewModel: ObservableObject {
     // User Profile
-    @Published var userData: UserEntity = UserEntity(nickname: "", major: "", myRank: MyRank(score: 0, ranking: 0), highestScore: 0, highestRank: "")
+    @Published var userData: UserEntity = UserEntity(nickname: "", major: "",
+                                                     myRank: MyRank(score: 0, ranking: 0),
+                                                     landmarkRank: MyRank(score: 0, ranking: 0),
+                                                     highestScore: 0, highestRank: "")
     @Published var badgeList: [BadgeResponse] = []
     @Published var attendanceList: [String] = []
     
@@ -166,7 +169,7 @@ final class HomeViewModel: ObservableObject {
                 if let response = data as? APIResponse {
                     if let myRank = response.response?.myRank {
                         DispatchQueue.main.async {
-                            self.userData.myRank = myRank
+                            self.userData.landmarkRank = myRank
                             print(self.userData)
                         }
                     }

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
@@ -21,13 +21,7 @@ struct LandmarkRankingView: View {
                 Color.black.opacity(0.2).ignoresSafeArea()
                 
                 let shouldPadding = geometry.size.height >= 700
-                let rankingList = [Ranking(nickname: "test1", score: 1000),
-                                   Ranking(nickname: "test2", score: 900),
-                                   Ranking(nickname: "test3", score: 800),
-                                   Ranking(nickname: "test4", score: 700),
-                                   Ranking(nickname: "test5", score: 600),
-                                   Ranking(nickname: "test6", score: 500),
-                                   Ranking(nickname: "test7", score: 400)]
+                let rankingList: [Ranking] = homeViewModel.landmarkRank
                 
                 VStack {
                     Spacer()
@@ -49,8 +43,8 @@ struct LandmarkRankingView: View {
                                     .overlay {
                                         Image(.landmarkScoreBackground)
                                             .overlay {
-                                                // TODO: 1등 플레이어 점수 가져오기
-                                                Text("+ 1,214")
+                                                // 1등 플레이어 점수
+                                                Text("+ \(rankingList[0].score.decimalFormatter)")
                                                     .font(.neo20)
                                                     .foregroundColor(.kuText)
                                                     .kerning(-0.41)
@@ -78,8 +72,8 @@ struct LandmarkRankingView: View {
                                             .foregroundColor(.kuText)
                                             .kerning(-0.41)
                                         
-                                        // TODO: 1등 플레이어 닉네임 가져오기
-                                        Text("건덕이")
+                                        // 1등 플레이어 닉네임
+                                        Text(rankingList[0].nickname)
                                             .font(.neo18)
                                             .foregroundColor(.kuTextDarkGreen)
                                             .kerning(-0.41) +
@@ -129,7 +123,7 @@ struct LandmarkRankingView: View {
                                     Image(.rankingMineRow)
                                         .overlay {
                                             HStack {
-                                                Text(String(homeViewModel.userData.myRank.ranking))
+                                                Text(String(homeViewModel.userData.landmarkRank.ranking))
                                                     .font(.neo18)
                                                     .kerning(-0.41)
                                                     .foregroundStyle(.kuText)
@@ -143,7 +137,7 @@ struct LandmarkRankingView: View {
                                                 
                                                 Spacer()
                                                 
-                                                Text(String(homeViewModel.userData.myRank.score.decimalFormatter))
+                                                Text(String(homeViewModel.userData.landmarkRank.score.decimalFormatter))
                                                     .font(.neo18)
                                                     .kerning(-0.41)
                                                     .foregroundStyle(.kuText)


### PR DESCRIPTION
### 🐣Issue
closed #127 
<br/>

### 🐣Motivation
LandmarkRankingView 로직 구현 및 API를 연결했습니다
<br/>

### 🐣Key Changes
랜드마크별 랭킹을 받아오기 위해 일부 코드를 수정했습니다.

`UserEntity` 내에 Landmark별 랭킹 멤버 변수 추가했습니다.
myRank는 토탈 랭킹, landmarkRank는 랜드마크별 랭킹을 저장합니다.

```swift
struct UserEntity {
    var nickname: String
    var major: String
    var myRank: MyRank // 전체 랭킹
    var landmarkRank: MyRank // 랜드마크별 랭킹 (추가)
    var highestScore: Int
    var highestRank: String
}
```

따라서 랜드마크별 랭킹 받아올 때 `landmarkRank` 변수에 저장해줍니다 (전체 랭킹은 `myRank`에 저장)
```swift
func loadLandmarkRanking(landmarkID: Int) {
    APIManager.callGETAPI(endpoint: .scoresRankLandmark, landmarkID: landmarkID) { result in
        switch result {
        case .success(let data):
            print("loadLandmarkRanking(): \(data)")
            
            if let response = data as? APIResponse {
                if let myRank = response.response?.myRank {
                    DispatchQueue.main.async {
                        self.userData.landmarkRank = myRank
                        print(self.userData)
                    }
                }
                
                if let rank = response.response?.rank {
                    DispatchQueue.main.async {
                        self.landmarkRank = rank // 추가 랜드마크 랭크에 저장하도록 수정
                        print(self.landmarkRank)
                    }
                }
            }
        case .failure(let error):
            print("Error in View: \(error)")
        }
    }
}
```

Total Ranking View와는 다른 부분이 1등의 닉네임, 점수 보여주는 부분과
```swift
// 1등 플레이어 점수
Text("+ \(rankingList[0].score.decimalFormatter)")
    .font(.neo20)
    .foregroundColor(.kuText)
    .kerning(-0.41)
// ....

// 1등 플레이어 닉네임
Text(rankingList[0].nickname)
    .font(.neo18)
    .foregroundColor(.kuTextDarkGreen)
    .kerning(-0.41) +
```

나의 랭킹 보여주는 부분 입니다. (여기에서 위에서 추가한 `landmarkRank`를 사용합니다)
```swift
Image(.rankingMineRow)
    .overlay {
        HStack {
            Text(String(homeViewModel.userData.landmarkRank.ranking)) // 수정
                .font(.neo18)
                .kerning(-0.41)
                .foregroundStyle(.kuText)
            
            Spacer()
            
            Text(StringLiterals.Home.me)
                .font(.pretendard15R)
                .foregroundStyle(.kuText)
                .frame(width: 104)
            
            Spacer()
            
            Text(String(homeViewModel.userData.landmarkRank.score.decimalFormatter)) // 수정
                .font(.neo18)
                .kerning(-0.41)
                .foregroundStyle(.kuText)
        }
        .padding(.horizontal, 22)
    }
    .padding(.horizontal, 16)
```
여기서 `myRank`를 사용하면 랜드마크별 나의 랭킹이 아니라 전체 랭킹이 뜨기 때문에 위와 같이 수정했습니다.

<br/>

### 🐣Simulation
| | 랭킹 예시 1 | 랭킹 예시 2 | 랭킹 없는 경우 |
|--|--|--|--|
| `LandmarkView` | <img width="200px" alt="" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/066896b7-e009-4b7e-9ec2-016d682fe4fc"> | <img width="200px" alt="" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/0197039c-25ca-475e-b2e2-bd135e48225b"> | <img width="200px" alt="" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/6e6aa7a0-1a4d-4414-8eb0-aafdfcf3743a"> |
| `LandmarkRankingView` | <img width="200px" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/5392dbe8-0eb3-47db-b59d-da1fd1190d9a" alt=""> | <img width="200px" alt="" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/a1368056-5377-48e0-949e-88aff470a612"> | <img width="200px" alt="" src="https://github.com/playkuround/playkuround-iOS/assets/37548919/46a2fa22-e34b-45f5-98e7-53b00d7a7219"> |

<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
