### PR TITLE
[Fix] #130 - MapView 수정사항 반영

### DIFF
--- a/playkuround-iOS/Views/Map/CustomMapAnnotationView.swift
+++ b/playkuround-iOS/Views/Map/CustomMapAnnotationView.swift
@@ -15,11 +15,7 @@ struct CustomMapAnnotationView: View {
         if annotation.type == .landmark {
             Image(.landmarkFlag)
         } else {
-            ZStack {
-                Image(.userAnnotationHeading)
-                    .rotationEffect(Angle(degrees: mapViewModel.userHeading))
-                Image(.userAnnotation)
-            }
+            Image(.userAnnotation)
         }
     }
 }

--- a/playkuround-iOS/Views/Map/MapView.swift
+++ b/playkuround-iOS/Views/Map/MapView.swift
@@ -17,7 +17,9 @@ struct MapView: View {
     @State private var annotationList: [AnnotationWrapper] = []
     
     var body: some View {
-        Map(coordinateRegion: $region, annotationItems: annotationList) { annotation in
+        let sortedAnnList = annotationList.sorted { $0.landmark.number > $1.landmark.number }
+        
+        Map(coordinateRegion: $region, annotationItems: sortedAnnList) { annotation in
             if annotation.type == .landmark {
                 MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: annotation.landmark.latitude, longitude: annotation.landmark.longitude)) {
                     // getAnnotation(annotation)
@@ -25,11 +27,13 @@ struct MapView: View {
                         .onTapGesture {
                             homeViewModel.openLandmarkView(landmarkID: annotation.landmark.number)
                         }
+                        .allowsHitTesting(true)
                 }
             } else {
                 MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: mapViewModel.userLatitude, longitude: mapViewModel.userLongitude)) {
                     CustomMapAnnotationView(annotation: annotation, mapViewModel: mapViewModel)
                         .onTapGesture { } // Not Used (MapKit 특성 상 대칭을 맞춰주어야 함)
+                        .allowsHitTesting(false) // 덕쿠 터치 무시
                 }
             }
         }


### PR DESCRIPTION
### 🐣Issue
closed #130 
<br/>

### 🐣Motivation
기획팀에서 요청한 MapView 수정사항을 반영했습니다
<br/>

### 🐣Key Changes
덕쿠 고깔모양 방향 인디케이터를 삭제했습니다.

```swift
var body: some View {
    if annotation.type == .landmark {
        Image(.landmarkFlag)
    } else {
        Image(.userAnnotation)
    }
}
```
<br/>

지도에서 깃발보다 덕쿠가 위로 오도록 정렬했습니다.
다만, Apple MapKit을 찾아보니 Annotation의 순서 지정은 원칙적으로 불가하나, 정렬한 후 순서대로 표시하면 더 위에 표시될 수는 있다고 하여 정렬하는 방식으로 해결하였으나, 이 문제를 기획팀에도 이야기하여 확인받았습니다.

```swift
let sortedAnnList = annotationList.sorted { $0.landmark.number > $1.landmark.number }
        
Map(coordinateRegion: $region, annotationItems: sortedAnnList) { annotation in
    if annotation.type == .landmark {
        MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: annotation.landmark.latitude, longitude: annotation.landmark.longitude)) {
            // getAnnotation(annotation)
            CustomMapAnnotationView(annotation: annotation, mapViewModel: mapViewModel)
                .onTapGesture {
                    homeViewModel.openLandmarkView(landmarkID: annotation.landmark.number)
                }
                .allowsHitTesting(true)
        }
    } else {
        MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: mapViewModel.userLatitude, longitude: mapViewModel.userLongitude)) {
            CustomMapAnnotationView(annotation: annotation, mapViewModel: mapViewModel)
                .onTapGesture { } // Not Used (MapKit 특성 상 대칭을 맞춰주어야 함)
                .allowsHitTesting(false) // 덕쿠 터치 무시
        }
    }
}
```
<br/>

### 🐣Simulation
| 수정 후 |
|--|
| <img width="300px" src="https://github.com/user-attachments/assets/69b6427e-fe9b-4a9a-bc5a-92120b83bd50" alt=""> |
<br/>

### 🐣To Reviewer
혹시 지도에서 Annotation의 상하관계를 지정할 수 있는 방법이 있다면 알려주세요!!
<br/>

### 🐣Reference
X
<br/>
