### PR TITLE
[Design] #151 - 새 뱃지 뷰 디자인 구현

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0C0CDA312C299021003D12BA /* AdventureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0CDA302C299021003D12BA /* AdventureView.swift */; };
 		0C27DDF02BBD714F0049B7B8 /* CardComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27DDEF2BBD714F0049B7B8 /* CardComponent.swift */; };
 		0C31576C2BB7CCC000F270F7 /* Landmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31576B2BB7CCC000F270F7 /* Landmark.swift */; };
+		0C3EFF682C7332B600A34CE1 /* NewBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3EFF672C7332B600A34CE1 /* NewBadgeView.swift */; };
 		0C3F4E732C0C477F00EE9DB6 /* LandmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3F4E722C0C477F00EE9DB6 /* LandmarkView.swift */; };
 		0C3F4E752C0C479700EE9DB6 /* LandmarkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3F4E742C0C479700EE9DB6 /* LandmarkDetailView.swift */; };
 		0C519D972BBADD6500DAA206 /* CardGameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C519D962BBADD6500DAA206 /* CardGameView.swift */; };
@@ -140,6 +141,7 @@
 		0C0CDA302C299021003D12BA /* AdventureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventureView.swift; sourceTree = "<group>"; };
 		0C27DDEF2BBD714F0049B7B8 /* CardComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponent.swift; sourceTree = "<group>"; };
 		0C31576B2BB7CCC000F270F7 /* Landmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Landmark.swift; sourceTree = "<group>"; };
+		0C3EFF672C7332B600A34CE1 /* NewBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBadgeView.swift; sourceTree = "<group>"; };
 		0C3F4E722C0C477F00EE9DB6 /* LandmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkView.swift; sourceTree = "<group>"; };
 		0C3F4E742C0C479700EE9DB6 /* LandmarkDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkDetailView.swift; sourceTree = "<group>"; };
 		0C519D962BBADD6500DAA206 /* CardGameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardGameView.swift; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 			children = (
 				B9A334ED2C0BA050006A6A24 /* BadgeView.swift */,
 				B99CD63C2C1026E2002B3755 /* BadgeDetailView.swift */,
+				0C3EFF672C7332B600A34CE1 /* NewBadgeView.swift */,
 			);
 			path = Badge;
 			sourceTree = "<group>";
@@ -931,6 +934,7 @@
 				0CA07D712BFDA98400564AEB /* SurviveGameViewModel.swift in Sources */,
 				B99CD63D2C1026E2002B3755 /* BadgeDetailView.swift in Sources */,
 				0C5979BC2BAB26A800E8156D /* TermsView.swift in Sources */,
+				0C3EFF682C7332B600A34CE1 /* NewBadgeView.swift in Sources */,
 				0C519D992BBAEB6C00DAA206 /* GameViewModel.swift in Sources */,
 				B98503C22BDCEC2900C3CC8F /* AllClickTextRainView.swift in Sources */,
 				0C6AA4CF2BA56FB30032AB24 /* ScoreType.swift in Sources */,

--- a/playkuround-iOS/Resources/StringLiterals.swift
+++ b/playkuround-iOS/Resources/StringLiterals.swift
@@ -108,6 +108,7 @@ enum StringLiterals {
             static let title = "배지"
             static let attendanceTitle = "출석 배지"
             static let adventureTitle = "탐험 배지"
+            static let new = "new!"
         }
         
         enum TotalRanking {

--- a/playkuround-iOS/Views/Home/Badge/NewBadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/NewBadgeView.swift
@@ -1,0 +1,60 @@
+//
+//  NewBadgeView.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 8/19/24.
+//
+
+import SwiftUI
+
+struct NewBadgeView: View {
+    let badge: Badge
+    
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.5).ignoresSafeArea()
+                .onTapGesture {
+                    // TODO: 화면 닫기
+                }
+            
+            Image(.badgePopup)
+                .overlay {
+                    VStack {
+                        badge.image
+                            .resizable()
+                            .frame(width: 120, height: 120)
+                            .padding(.bottom, 16)
+                        
+                        HStack(alignment: .center, spacing: 8) {
+                            // 뱃지 글자 가운데 오도록
+                            Spacer()
+                                .frame(width: 24)
+                            
+                            Text(badge.title)
+                                .font(.neo20)
+                                .kerning(-0.41)
+                                .foregroundStyle(.kuText)
+                            
+                            Text(StringLiterals.Home.Badge.new)
+                                .font(.neo15)
+                                .kerning(-0.41)
+                                .foregroundStyle(.kuTimebarRed)
+                                .padding(.bottom, 4)
+                        }
+                        .padding(.bottom, 16)
+                        
+                        Text(badge.description)
+                            .font(.pretendard15R)
+                            .foregroundStyle(.kuText)
+                            .lineSpacing(15 * 0.3)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.horizontal, 48)
+                }
+        }
+    }
+}
+
+#Preview {
+    NewBadgeView(badge: .ATTENDANCE_1)
+}


### PR DESCRIPTION
### 🐣Issue
closed #151 
<br/>

### 🐣Motivation
새 뱃지 뷰 디자인을 구현했습니다
<br/>

### 🐣Key Changes
새 뱃지 뷰 (`NewBadgeView`) 구현
<br/>

### 🐣Simulation
| 5.5" | 6.5" | 6.7" |
|--|--|--|
| <img width="300px" alt="" src="https://github.com/user-attachments/assets/852dc8c9-c7fe-4976-8a6e-ffb2797cd8e6"> | <img width="300px" alt="" src="https://github.com/user-attachments/assets/69ff3177-4a67-48ae-916d-a19d69ffd371"> | <img width="300px" alt="" src="https://github.com/user-attachments/assets/0ef50353-35bd-4c9f-818b-084beb751d3b"> |
<br/>

### 🐣To Reviewer
공식 디자인이 없어 예전에 문의해본 결과 안드로이드와 비슷하게 만들면 된다고 해서 비슷하게 만들었습니다. (정확한 수치 자료는 없어 눈대중으로 맞추었습니다) 
* new! 빼고는 기존 뱃지 디테일 뷰의 재활용입니다 (디자인팀 검토 완료) 

| 안드로이드 캡쳐 |
|--|
| <img width="200px" alt="Screenshot 2024-08-19 at 17 01 17" src="https://github.com/user-attachments/assets/5a3fe206-e6fa-46a9-b942-610f4ef39fa2"> |

<br/>

### 🐣Reference
X
<br/>
