### PR TITLE
[Fix] #159 - 게임 중단 및 기타 오류 수정

### DIFF
--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -176,7 +176,7 @@ class GameViewModel: ObservableObject {
         // TODO: 게임 종료 처리 (점수 계산 등)
         
         // 서버로 점수 업로드
-        uploadResult()
+        uploadResult(uploadScore: 0)
     }
     
     // 게임 중도 중지 후 홈으로 이동
@@ -331,7 +331,7 @@ class GameViewModel: ObservableObject {
     // MARK: - 서버 API 관련 함수
     
     // 서버로 점수 업로드 함수
-    final func uploadResult() {
+    final func uploadResult(uploadScore: Int) {
 //        // 사용자 위치 정보
 //        let latitude = mapViewModel.userLatitude
 //        let longitude = mapViewModel.userLongitude
@@ -340,6 +340,8 @@ class GameViewModel: ObservableObject {
         let longitude: Double = 127.07920
         let landmarkID = 25 // 신공학관
         
+        print("** ready to upload score: \(uploadScore)점")
+        
 //        if let landmarkID = mapViewModel.userLandmarkID {
             // Adventure API 호출
             // 전송 실패하더라도 callPOSTAPI 함수 내부에서 재전송 처리
@@ -347,7 +349,7 @@ class GameViewModel: ObservableObject {
                                    parameters: ["landmarkId": landmarkID,
                                                 "latitude": latitude,
                                                 "longitude": longitude,
-                                                "score": score,
+                                                "score": uploadScore,
                                                 "scoreType": gameType.rawValue])
             { result in
                 switch result {

--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -129,9 +129,12 @@ class GameViewModel: ObservableObject {
     
     // 시작 전 3초 카운트다운 시작 함수
     final func startCountdown() {
-        gameState = .countdown
-        withAnimation(.spring(duration: 0.1)) {
-            isCountdownViewPresented = true
+        DispatchQueue.main.async {
+            self.gameState = .countdown
+            
+            withAnimation(.spring(duration: 0.1)) {
+                self.isCountdownViewPresented = true
+            }
         }
         
         // 카운트다운 시작
@@ -158,13 +161,17 @@ class GameViewModel: ObservableObject {
     // 게임 시작 시 호출 함수
     func startGame() {
         // TODO: 게임 시작 프로세스 호출
-        gameState = .playing
+        DispatchQueue.main.async {
+            self.gameState = .playing
+        }
         print("Game is started")
     }
     
     // 게임 완료 (사용자가 끝까지 마친 경우)
     func finishGame() {
-        gameState = .finish
+        DispatchQueue.main.async {
+            self.gameState = .finish
+        }
         print("Game is finished")
         // TODO: 게임 종료 처리 (점수 계산 등)
         
@@ -175,7 +182,9 @@ class GameViewModel: ObservableObject {
     // 게임 중도 중지 후 홈으로 이동
     func stopGame() {
         // TODO: 게임 중단 프로세스
-        gameState = .stop
+        DispatchQueue.main.async {
+            self.gameState = .stop
+        }
         print("Game is stopped")
         
         // 홈으로 이동
@@ -187,35 +196,45 @@ class GameViewModel: ObservableObject {
     // 게임 타이머 시작
     final func startTimer() {
         print("timer is started")
-        isTimerUpdating = true
+        DispatchQueue.main.async {
+            self.isTimerUpdating = true
+        }
     }
     
     // 타이머 일시정지 및 재시작
     func pauseOrRestartTimer() {
         print("timer is paused")
-        isTimerUpdating.toggle()
+        DispatchQueue.main.async {
+            self.isTimerUpdating.toggle()
+        }
     }
     
     // 타이머 삭제
     final func cancelTimer() {
         print("timer is stopped")
-        isTimerUpdating = false
-        timer.upstream.connect().cancel()
+        DispatchQueue.main.async {
+            self.isTimerUpdating = false
+            self.timer.upstream.connect().cancel()
+        }
     }
     
     // 타이머 초기화
     final func resetTimer() {
         print("timer is reseted")
-        isTimerUpdating = false
-        timeRemaining = timeStart
-        progress = 1.0
+        DispatchQueue.main.async {
+            self.isTimerUpdating = false
+            self.timeRemaining = self.timeStart
+            self.progress = 1.0
+        }
         updateTimeString()
     }
     
     // 타이머가 끝난 경우 호출되는 함수
     // 사용자가 재정의
     func timerDone() {
-        self.finishGame()
+        DispatchQueue.main.async {
+            self.finishGame()
+        }
     }
     
     // 타이머 업데이트
@@ -223,14 +242,18 @@ class GameViewModel: ObservableObject {
         if isTimerUpdating {
             // 감소
             if self.isTimerDecreasing && self.timeRemaining > self.timeEnd {
-                self.timeRemaining -= self.timeInterval
-                self.progress = self.timeRemaining / self.timeStart
+                DispatchQueue.main.async {
+                    self.timeRemaining -= self.timeInterval
+                    self.progress = self.timeRemaining / self.timeStart
+                }
                 self.updateTimeString()
             }
             // 증가
             else if !self.isTimerDecreasing && self.timeRemaining < self.timeEnd {
                 // 증가하는 경우 progress 계산 X
-                self.timeRemaining += self.timeInterval
+                DispatchQueue.main.async {
+                    self.timeRemaining += self.timeInterval
+                }
                 self.updateTimeString()
             }
             // 시간 다 된 경우
@@ -245,14 +268,18 @@ class GameViewModel: ObservableObject {
         if isTimerUpdating {
             // 감소
             if self.isTimerDecreasing && self.timeRemaining > self.timeEnd {
-                self.timeRemaining -= self.timeInterval
-                self.progress = self.timeRemaining / self.timeStart
+                DispatchQueue.main.async {
+                    self.timeRemaining -= self.timeInterval
+                    self.progress = self.timeRemaining / self.timeStart
+                }
                 self.updateTimeString()
             }
             // 증가
             else if !self.isTimerDecreasing && self.timeRemaining < self.timeEnd {
                 // 증가하는 경우 progress 계산 X
-                self.timeRemaining += self.timeInterval
+                DispatchQueue.main.async {
+                    self.timeRemaining += self.timeInterval
+                }
                 self.updateTimeString()
             }
             // 시간 다 된 경우
@@ -267,8 +294,10 @@ class GameViewModel: ObservableObject {
     final func updateTimeString() {
         let minute = Int(timeRemaining) / 60
         let second = Int(timeRemaining) % 60
-        self.minute = String(format: "%02d", minute)
-        self.second = String(format: "%02d", second)
+        DispatchQueue.main.async {
+            self.minute = String(format: "%02d", minute)
+            self.second = String(format: "%02d", second)
+        }
     }
     
     // MARK: - 일시정지 뷰
@@ -292,8 +321,10 @@ class GameViewModel: ObservableObject {
     
     // 모든 API 호출 이후 호출되는 함수
     func afterFetch() {
-        withAnimation(.spring) {
-            self.isResultViewPresented = true
+        DispatchQueue.main.async {
+            withAnimation(.spring) {
+                self.isResultViewPresented = true
+            }
         }
     }
     
@@ -368,7 +399,9 @@ class GameViewModel: ObservableObject {
                 self.fetchAdventureScore()
             case .failure(let error):
                 print("Error in View: \(error)")
-                self.bestScore = 0
+                DispatchQueue.main.async {
+                    self.bestScore = 0
+                }
                 self.fetchAdventureScore()
             }
         }

--- a/playkuround-iOS/Views/Games/CardGame/CardGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/CardGame/CardGameViewModel.swift
@@ -37,21 +37,22 @@ final class CardGameViewModel: GameViewModel {
     }
     
     override func timerDone() {
-        finishGame()
+        self.finishGame()
     }
     
     override func finishGame() {
-        gameState = .finish
-        
-        // 최종 점수 계산
-        // 맞춘 카드 쌍 * 5점, 시간 * 2
-        score = correctCount * 5 / 2
-        score += Int(timeRemaining) * 2
-        
-        print("final score: \(score)")
-    
-        // 서버로 점수 업로드
-        uploadResult()
+        DispatchQueue.main.async {
+            self.gameState = .finish
+            
+            // 최종 점수 계산
+            // 맞춘 카드 쌍 * 5점, 시간 * 2
+            self.score = self.correctCount * 5 / 2
+            self.score += Int(self.timeRemaining) * 2
+            
+            // 서버로 점수 업로드
+            print("score: \(self.score), time: \(self.timeRemaining), correctCount: \(self.correctCount)")
+            super.uploadResult(uploadScore: self.score)
+        }
     }
     
     func shuffleCard() {
@@ -91,7 +92,7 @@ final class CardGameViewModel: GameViewModel {
         
         if correctCount == 16 {
             super.pauseOrRestartTimer()
-            super.finishGame()
+            self.finishGame()
         }
     }
     

--- a/playkuround-iOS/Views/Games/CatchGame/CatchGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/CatchGame/CatchGameViewModel.swift
@@ -42,7 +42,7 @@ final class CatchGameViewModel: GameViewModel {
         self.isTimerUpdating = false
         
         // 서버로 점수 업로드
-        uploadResult()
+        uploadResult(uploadScore: self.score)
     }
     
     func step(whiteNum: Int, blackNum: Int) {

--- a/playkuround-iOS/Views/Games/CupidGame/CupidGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/CupidGame/CupidGameViewModel.swift
@@ -45,7 +45,7 @@ final class CupidGameViewModel: GameViewModel {
         stopDuckSpawn()
         
         // 서버로 점수 업로드
-        uploadResult()
+        uploadResult(uploadScore: score)
     }
     
     func startDuckAnimation() {

--- a/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/MoonGame/MoonGameViewModel.swift
@@ -13,31 +13,41 @@ final class MoonGameViewModel: GameViewModel {
     
     func moonClick() {
         if 81 < moonTapped && moonTapped <= 100 {
-            moonTapped -= 1
-            moonState = .fullMoon
+            DispatchQueue.main.async {
+                self.moonTapped -= 1
+                self.moonState = .fullMoon
+            }
         }
         else if 51 < moonTapped && moonTapped <= 81 {
-            moonTapped -= 1
-            moonState = .cracked
+            DispatchQueue.main.async {
+                self.moonTapped -= 1
+                self.moonState = .cracked
+            }
         }
         else if 1 < moonTapped && moonTapped <= 51 {
-            moonTapped -= 1
-            moonState = .moreCracked
+            DispatchQueue.main.async {
+                self.moonTapped -= 1
+                self.moonState = .moreCracked
+            }
         }
         else if moonTapped == 1 {
-            moonTapped = 0
-            moonState = .duck
-            score = 20
+            DispatchQueue.main.async {
+                self.moonTapped = 0
+                self.moonState = .duck
+                self.score = 20
+            }
             finishGame()
         }
     }
     
     override func finishGame() {
-        gameState = .finish
+        DispatchQueue.main.async {
+            self.gameState = .finish
+        }
         
         // 3초 뒤 서버로 점수 업로드
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            super.uploadResult()
+            super.uploadResult(uploadScore: self.score)
         }
     }
 }

--- a/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
@@ -54,7 +54,7 @@ final class QuizGameViewModel: GameViewModel {
         
         // 3초 뒤 서버로 점수 업로드
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            super.uploadResult()
+            super.uploadResult(uploadScore: self.score)
         }
     }
 }

--- a/playkuround-iOS/Views/Games/SurviveGame/SurviveGameView.swift
+++ b/playkuround-iOS/Views/Games/SurviveGame/SurviveGameView.swift
@@ -91,20 +91,16 @@ struct SurviveGameView: View {
                         .overlay {
                             ForEach(viewModel.bugList, id: \.self) { bug in
                                 entityView(type: .bug, angle: bug.angle)
-                                    .border(.green)
                                     .offset(x: bug.posX, y: bug.posY)
                             }
                             
                             ForEach(viewModel.boatList, id: \.self) { boat in
                                 entityView(type: .boat, angle: boat.angle)
-                                    .border(.blue)
                                     .rotationEffect(boat.angle)
-                                    .border(.orange)
                                     .offset(x: boat.posX, y: boat.posY)
                             }
                             
                             Image(viewModel.isTransparent ? .surviveDuckkuHit : .surviveDuckku)
-                                .border(.red)
                                 .offset(x: viewModel.duckkuPosX, y: viewModel.duckkuPosY)
                         }
                     }

--- a/playkuround-iOS/Views/Games/SurviveGame/SurviveGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/SurviveGame/SurviveGameViewModel.swift
@@ -72,7 +72,7 @@ final class SurviveGameViewModel: GameViewModel {
         gameState = .finish
     
         // 서버로 점수 업로드
-        uploadResult()
+        uploadResult(uploadScore: self.score)
     }
     
     func setFrameXY(x: CGFloat, y: CGFloat) {

--- a/playkuround-iOS/Views/Games/SurviveGame/SurviveGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/SurviveGame/SurviveGameViewModel.swift
@@ -68,11 +68,13 @@ final class SurviveGameViewModel: GameViewModel {
     
     override func finishGame() {
         super.pauseOrRestartTimer()
-        self.isTimerUpdating = false
-        gameState = .finish
-    
-        // 서버로 점수 업로드
-        uploadResult(uploadScore: self.score)
+        DispatchQueue.main.async {
+            self.isTimerUpdating = false
+            self.gameState = .finish
+            
+            // 서버로 점수 업로드
+            super.uploadResult(uploadScore: self.score)
+        }
     }
     
     func setFrameXY(x: CGFloat, y: CGFloat) {
@@ -81,37 +83,39 @@ final class SurviveGameViewModel: GameViewModel {
     }
     
     private func updateDuckkuPos(x: Double, y: Double, z: Double) {
-        if !isTimerUpdating {
+        if !self.isTimerUpdating {
             return
         }
         
-        self.gyroCummX += x * 0.1
-        self.gyroCummY += y * 0.1
-        
-        self.gyroCummX = min(max(self.gyroCummX, -2), 2)
-        self.gyroCummY = min(max(self.gyroCummY, -2), 2)
-        
-        // Gyro data scaling factor
-        let scalingFactor: CGFloat = 1.0
-        let damping: CGFloat = 0.5
-    
-        // Update acceleration based on gyro data
-        accelerationX = CGFloat(gyroCummY) * scalingFactor
-        accelerationY = CGFloat(gyroCummX) * scalingFactor
-        
-        // Update velocity with damping to simulate friction
-        velocityX += accelerationX
-        velocityY += accelerationY
-        velocityX *= damping
-        velocityY *= damping
-        
-        // Update positions
-        let newX = duckkuPosX + velocityX
-        let newY = duckkuPosY + velocityY
-        
-        // Constrain positions within frame
-        duckkuPosX = min(max(newX, -frameMaxX / 2), frameMaxX / 2)
-        duckkuPosY = min(max(newY, -frameMaxY / 2), frameMaxY / 2)
+        DispatchQueue.main.async {
+            self.gyroCummX += x * 0.1
+            self.gyroCummY += y * 0.1
+            
+            self.gyroCummX = min(max(self.gyroCummX, -2), 2)
+            self.gyroCummY = min(max(self.gyroCummY, -2), 2)
+            
+            // Gyro data scaling factor
+            let scalingFactor: CGFloat = 1.0
+            let damping: CGFloat = 0.5
+            
+            // Update acceleration based on gyro data
+            self.accelerationX = CGFloat(self.gyroCummY) * scalingFactor
+            self.accelerationY = CGFloat(self.gyroCummX) * scalingFactor
+            
+            // Update velocity with damping to simulate friction
+            self.velocityX += self.accelerationX
+            self.velocityY += self.accelerationY
+            self.velocityX *= damping
+            self.velocityY *= damping
+            
+            // Update positions
+            let newX = self.duckkuPosX + self.velocityX
+            let newY = self.duckkuPosY + self.velocityY
+            
+            // Constrain positions within frame
+            self.duckkuPosX = min(max(newX, -self.frameMaxX / 2), self.frameMaxX / 2)
+            self.duckkuPosY = min(max(newY, -self.frameMaxY / 2), self.frameMaxY / 2)
+        }
     }
     
     private func setupGyroUpdates() {

--- a/playkuround-iOS/Views/Games/TimerGame/TimerGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/TimerGame/TimerGameViewModel.swift
@@ -53,7 +53,7 @@ final class TimerGameViewModel: GameViewModel {
     
         // 3초 뒤 서버로 점수 업로드
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            super.uploadResult()
+            super.uploadResult(uploadScore: self.score)
         }
     }
 }


### PR DESCRIPTION
### 🐣Issue
closed #159
<br/>

### 🐣Motivation
게임 중단 및 기타 오류를 수정합니다
<br/>

### 🐣Key Changes
1. 카운트다운 중 게임이 중단되는 오류 수정
```swift
final func startCountdown() {
    DispatchQueue.main.async {
        self.gameState = .countdown // 이 부분이 처리가 안되어 있었음
         
        withAnimation(.spring(duration: 0.1)) {
            self.isCountdownViewPresented = true
        }
    }
    
    // 카운트다운 시작
    self.countdownProgress()
}
```

2. `GameViewModel` 내 `@Published` 변수 메인 스레드 실행 보장 처리
3. 다른 게임들 Child ViewModel 내 `@Published` 변수 메인 스레드 실행 보장 처리 (문제 생길 수 있는 부분 일부)
4. 일감호에서 살아남기 게임 중지 후에도 엔티티 움직이고 점수 증가하던 오류 수정
5. 카드 뒤집기 게임 점수가 올바르게 업로드되지 않는 문제 수정

다른 게임들은 코드 보고 플레이해보았는데 문제가 발견되지 않음 (+ 점수 업로드 잘 되는 것까지 확인 완료)
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
`ObservedObject`의 `@Published` 변수는 반드시 값 업데이트 시 `DispatchQueue.main.async` 내부에서 해주어야 한다고 합니다. 안그러면 Race Condition이나 데드락이 발생할 수 있다고 해요. 일단 GameViewModel 내 코드와 다른 게임들도 코드 보고 게임 돌려보며 수정했습니다. 추후 작업하실 때 참고해주세요!! 

일단 다른 게임 내 사소한 오류나 밸런스 등 문제는 다른 팀원분들께서 안드로이드와 비교하여 찾아주어야 할 것 같습니다. 지금 여러 번 테스트해본 결과 오류는 발견되지 않았습니다.

그리고 GameViewModel에 `uploadResult` 함수가 지금 신공학관으로만 고정해서 점수를 올리게 되어있어서 추후 릴리즈 직전에 수정하겠습니다
<br/>

### 🐣Reference
X
<br/>
