### PR TITLE
[Feat] #164 - 학과 2개 추가

### DIFF
--- a/playkuround-iOS/Models/Major.swift
+++ b/playkuround-iOS/Models/Major.swift
@@ -110,6 +110,10 @@ let majorList: [College] = [
     ]),
     College(name: "상허교양대학", majors: [
         Major(name: "국제학부")
+    ]),
+    College(name: "국제통상학/문화미디어학", majors: [
+        Major(name: "국제통상학과"),
+        Major(name: "문화미디어학과")
     ])
 ]
 


### PR DESCRIPTION
### 🐣Issue
closed #164 
<br/>

### 🐣Motivation
백엔드 측 수정사항 반영하여 학과 2개 추가했습니다. 
찾아봤는데 단과대는 없고 특수과인 것 같은데 "기타"라고 하기에는 좀 그래서 두개를 묶어서 단과대에 표시되도록 했습니다.
<br/>

### 🐣Key Changes
`Major.swift`에 학과 2개 (단과대 1개) 제외 없음 
<br/>

```swift
let majorList: [College] = [
    // ...
    College(name: "국제통상학/문화미디어학", majors: [
        Major(name: "국제통상학과"),
        Major(name: "문화미디어학과")
    ])
```
<br/>

### 🐣Simulation
| 단과대 선택 | 학과 선택 |
|--|--|
| <img width="300px" alt="" src="https://github.com/user-attachments/assets/51326f84-0c43-4916-936e-79fe6ff3e395"> | <img width="300px" alt="" src="https://github.com/user-attachments/assets/cce7396a-8baf-42fb-8580-ef75da70fcc9"> |

<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
