### PR TITLE
[Feat] #146 - 프로필 뱃지 선택 기능 구현 및 홈, 랭킹 프로필 이미지 기능 구현

### DIFF
--- a/playkuround-iOS/Extensions/Managers/APIManager.swift
+++ b/playkuround-iOS/Extensions/Managers/APIManager.swift
@@ -797,6 +797,7 @@ struct Response: Codable {
     let highestScore: Int?
     let highestRank: String?
     let attendanceDays: Int?
+    let profileBadge: String?
     
     // 게임별 최고 점수 얻기 (/api/users/game-score)
     let highestTotalScore: Int?

--- a/playkuround-iOS/Extensions/Managers/APIManager.swift
+++ b/playkuround-iOS/Extensions/Managers/APIManager.swift
@@ -87,6 +87,8 @@ final class APIManager {
         case fakeDoor = "/api/fake-door"
         // 회원가입
         case register = "/api/users/register"
+        // 프로필 뱃지 설정
+        case profileBadge = "/api/users/profile-badge"
         // 로그아웃
         case logout = "/api/users/logout"
     }
@@ -715,6 +717,17 @@ struct APIManagerTestView: View {
                             }
                         }
                         
+                        Button("프로필 뱃지 설정 - /api/users/profile-badge") {
+                            APIManager.callPOSTAPI(endpoint: .profileBadge, parameters: ["profileBadge": "ATTENDANCE_1"]) { result in
+                                switch result {
+                                case .success(let data):
+                                    print("(success) /api/users/profile-badge: \(data)")
+                                case .failure(let error):
+                                    print("(fail) /api/users/profile-badge: \(error)")
+                                }
+                            }
+                        }
+                        
                         Button("로그아웃 - /api/users/logout") {
                             APIManager.callPOSTAPI(endpoint: .logout) { result in
                                 switch result {
@@ -729,10 +742,10 @@ struct APIManagerTestView: View {
                 }
             }
         }
-        .onAppear {
+        /* .onAppear {
             // 테스트 하기 위해 토큰을 제거
             TokenManager.reset()
-        }
+        } */
     }
 }
 
@@ -820,11 +833,13 @@ struct BadgeResponse: Codable {
 struct MyRank: Codable {
     var score: Int
     var ranking: Int
+    var profileBadge: String
 }
 
 struct Ranking: Codable {
     let nickname: String
     let score: Int
+    let profileBadge: String
 }
 
 // MARK: - 특이한 반환을 가진 API용 struct 따로 구현

--- a/playkuround-iOS/Models/Badge.swift
+++ b/playkuround-iOS/Models/Badge.swift
@@ -9,65 +9,65 @@ import SwiftUI
 
 enum Badge: String, CaseIterable {
     // 출석 관련 뱃지
-    case ATTENDANCE_1 = "첫 출석"
-    case ATTENDANCE_5 = "5회 출석"
-    case ATTENDANCE_10 = "10회 출석"
-    case ATTENDANCE_30 = "30회 출석"
-    case ATTENDANCE_50 = "50회 출석"
-    case ATTENDANCE_100 = "100회 출석"
+    case ATTENDANCE_1 = "ATTENDANCE_1"
+    case ATTENDANCE_5 = "ATTENDANCE_5"
+    case ATTENDANCE_10 = "ATTENDANCE_10"
+    case ATTENDANCE_30 = "ATTENDANCE_30"
+    case ATTENDANCE_50 = "ATTENDANCE_50"
+    case ATTENDANCE_100 = "ATTENDANCE_100"
     
     // 기념일 뱃지
-    case ATTENDANCE_FOUNDATION_DAY = "05월 15일 개교 기념일에 출석"
-    case ATTENDANCE_ARBOR_DAY = "04월 05일 식목일에 출석"
-    case ATTENDANCE_CHILDREN_DAY = "05월 05일 어린이날에 출석"
-    case ATTENDANCE_WHITE_DAY = "03월 14일 화이트데이에 출석"
-    case ATTENDANCE_DUCK_DAY = "05월 02일 오리데이에 출석"
+    case ATTENDANCE_FOUNDATION_DAY = "ATTENDANCE_FOUNDATION_DAY"
+    case ATTENDANCE_ARBOR_DAY = "ATTENDANCE_ARBOR_DAY"
+    case ATTENDANCE_CHILDREN_DAY = "ATTENDANCE_CHILDREN_DAY"
+    case ATTENDANCE_WHITE_DAY = "ATTENDANCE_WHITE_DAY"
+    case ATTENDANCE_DUCK_DAY = "ATTENDANCE_DUCK_DAY"
     
     // 2024 가을학기 추가 뱃지
-     case ATTENDANCE_CHUSEOK_DAY = "09월 17일 추석날에 출석"
-     case ATTENDANCE_KOREAN_DAY = "10월 09일 한글날에 출석"
-     case ATTENDANCE_DOKDO_DAY = "10월 25일 독도의 날에 출석"
-     case ATTENDANCE_KIMCHI_DAY = "11월 22일 김치의 날에 출석"
-     case ATTENDANCE_CHRISTMAS_DAY = "12월 25일 성탄절에 출석"
+     case ATTENDANCE_CHUSEOK_DAY = "ATTENDANCE_CHUSEOK_DAY"
+     case ATTENDANCE_KOREAN_DAY = "ATTENDANCE_KOREAN_DAY"
+     case ATTENDANCE_DOKDO_DAY = "ATTENDANCE_DOKDO_DAY"
+     case ATTENDANCE_KIMCHI_DAY = "ATTENDANCE_KIMCHI_DAY"
+     case ATTENDANCE_CHRISTMAS_DAY = "ATTENDANCE_CHRISTMAS_DAY"
     
     // 대학별 뱃지
-    case COLLEGE_OF_LIBERAL_ARTS = "문과대학 1회 이상 탐험"
-    case COLLEGE_OF_SCIENCES = "이과대학 1회 이상 탐험"
-    case COLLEGE_OF_ARCHITECTURE = "건축대학 1회 이상 탐험"
-    case COLLEGE_OF_ENGINEERING = "공과대학 1회 이상 탐험"
-    case COLLEGE_OF_SOCIAL_SCIENCES = "사회과학대학 1회 이상 탐험"
-    case COLLEGE_OF_BUSINESS_ADMINISTRATION = "경영대학 1회 이상 탐험"
-    case COLLEGE_OF_REAL_ESTATE = "부동산과학원 1회 이상 탐험"
-    case COLLEGE_OF_INSTITUTE_TECHNOLOGY = "융합과학기술원 1회 이상 탐험"
-    case COLLEGE_OF_BIOLOGICAL_SCIENCES = "생명과학대학 1회 이상 탐험"
-    case COLLEGE_OF_VETERINARY_MEDICINE = "수의과대학 1회 이상 탐험"
-    case COLLEGE_OF_ART_AND_DESIGN = "예술디자인대학 1회 이상 탐험"
-    case COLLEGE_OF_EDUCATION = "사범대학 1회 이상 탐험"
+    case COLLEGE_OF_LIBERAL_ARTS = "COLLEGE_OF_LIBERAL_ARTS"
+    case COLLEGE_OF_SCIENCES = "COLLEGE_OF_SCIENCES"
+    case COLLEGE_OF_ARCHITECTURE = "COLLEGE_OF_ARCHITECTURE"
+    case COLLEGE_OF_ENGINEERING = "COLLEGE_OF_ENGINEERING"
+    case COLLEGE_OF_SOCIAL_SCIENCES = "COLLEGE_OF_SOCIAL_SCIENCES"
+    case COLLEGE_OF_BUSINESS_ADMINISTRATION = "COLLEGE_OF_BUSINESS_ADMINISTRATION"
+    case COLLEGE_OF_REAL_ESTATE = "COLLEGE_OF_REAL_ESTATE"
+    case COLLEGE_OF_INSTITUTE_TECHNOLOGY = "COLLEGE_OF_INSTITUTE_TECHNOLOGY"
+    case COLLEGE_OF_BIOLOGICAL_SCIENCES = "COLLEGE_OF_BIOLOGICAL_SCIENCES"
+    case COLLEGE_OF_VETERINARY_MEDICINE = "COLLEGE_OF_VETERINARY_MEDICINE"
+    case COLLEGE_OF_ART_AND_DESIGN = "COLLEGE_OF_ART_AND_DESIGN"
+    case COLLEGE_OF_EDUCATION = "COLLEGE_OF_EDUCATION"
     
     // 경영대 특별 뱃지
-    case COLLEGE_OF_BUSINESS_ADMINISTRATION_10 = "경영대학 10회 이상 탐험"
-    case COLLEGE_OF_BUSINESS_ADMINISTRATION_30 = "경영대학 30회 이상 탐험"
-    case COLLEGE_OF_BUSINESS_ADMINISTRATION_50 = "경영대학 50회 이상 탐험"
-    case COLLEGE_OF_BUSINESS_ADMINISTRATION_70 = "경영대학 70회 이상 탐험"
-    case COLLEGE_OF_BUSINESS_ADMINISTRATION_100_AND_FIRST_PLACE = "경영대학 100회 이상 탐험 및 1등 달성"
+    case COLLEGE_OF_BUSINESS_ADMINISTRATION_10 = "COLLEGE_OF_BUSINESS_ADMINISTRATION_10"
+    case COLLEGE_OF_BUSINESS_ADMINISTRATION_30 = "COLLEGE_OF_BUSINESS_ADMINISTRATION_30"
+    case COLLEGE_OF_BUSINESS_ADMINISTRATION_50 = "COLLEGE_OF_BUSINESS_ADMINISTRATION_50"
+    case COLLEGE_OF_BUSINESS_ADMINISTRATION_70 = "COLLEGE_OF_BUSINESS_ADMINISTRATION_70"
+    case COLLEGE_OF_BUSINESS_ADMINISTRATION_100_AND_FIRST_PLACE = "COLLEGE_OF_BUSINESS_ADMINISTRATION_100_AND_FIRST_PLACE"
     
     // 예디대 특별 뱃지
-    case COLLEGE_OF_ART_AND_DESIGN_BEFORE_NOON = "예술디자인대학 09:00 ~ 11:59 탐험"
-    case COLLEGE_OF_ART_AND_DESIGN_AFTER_NOON = "예술디자인대학 12:00 ~ 18:00 탐험"
-    case COLLEGE_OF_ART_AND_DESIGN_NIGHT = "예술디자인대학 23:00 ~ 04:00 탐험"
+    case COLLEGE_OF_ART_AND_DESIGN_BEFORE_NOON = "COLLEGE_OF_ART_AND_DESIGN_BEFORE_NOON"
+    case COLLEGE_OF_ART_AND_DESIGN_AFTER_NOON = "COLLEGE_OF_ART_AND_DESIGN_AFTER_NOON"
+    case COLLEGE_OF_ART_AND_DESIGN_NIGHT = "COLLEGE_OF_ART_AND_DESIGN_NIGHT"
     
     // 공대 특별 뱃지
-    case COLLEGE_OF_ENGINEERING_A = "공대 A동 10회 이상 탐험"
-    case COLLEGE_OF_ENGINEERING_B = "공대 B동 10회 이상 탐험"
-    case COLLEGE_OF_ENGINEERING_C = "공대 C동 10회 이상 탐험"
+    case COLLEGE_OF_ENGINEERING_A = "COLLEGE_OF_ENGINEERING_A"
+    case COLLEGE_OF_ENGINEERING_B = "COLLEGE_OF_ENGINEERING_B"
+    case COLLEGE_OF_ENGINEERING_C = "COLLEGE_OF_ENGINEERING_C"
     
     // 스토리용 뱃지
-    case THE_DREAM_OF_DUCK = "스토리 컷씬 마스터"
+    case THE_DREAM_OF_DUCK = "THE_DREAM_OF_DUCK"
     
     // 월간랭킹 관련 뱃지
-    case MONTHLY_RANKING_1 = "월간 랭킹 1등"
-    case MONTHLY_RANKING_2 = "월간 랭킹 2등"
-    case MONTHLY_RANKING_3 = "월간 랭킹 3등"
+    case MONTHLY_RANKING_1 = "MONTHLY_RANKING_1"
+    case MONTHLY_RANKING_2 = "MONTHLY_RANKING_2"
+    case MONTHLY_RANKING_3 = "MONTHLY_RANKING_3"
     
     /// 뱃지 제목
     var title: String {
@@ -296,4 +296,38 @@ enum Badge: String, CaseIterable {
         case .MONTHLY_RANKING_3: return Image(.ranking3)
         }
     }
+}
+
+struct BadgeTestView: View {
+    @State private var selectedBadge: Badge? = nil
+    @State private var text: String = ""
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            if let badge = selectedBadge {
+                badge.image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 64, height: 64)
+                Text(badge.description)
+                Text(badge.title)
+                Text(badge.lockDescription)
+                Text(badge.rawValue)
+            } else {
+                Text("No matching badge")
+            }
+            
+            TextField("badge_name", text: $text)
+                .border(Color.gray, width: 1)
+                .padding(.horizontal, 30)
+            
+            Button("hit") {
+                selectedBadge = Badge(rawValue: text.uppercased())
+            }
+        }
+    }
+}
+
+#Preview {
+    BadgeTestView()
 }

--- a/playkuround-iOS/Models/Badge.swift
+++ b/playkuround-iOS/Models/Badge.swift
@@ -297,37 +297,3 @@ enum Badge: String, CaseIterable {
         }
     }
 }
-
-struct BadgeTestView: View {
-    @State private var selectedBadge: Badge? = nil
-    @State private var text: String = ""
-    
-    var body: some View {
-        VStack(spacing: 10) {
-            if let badge = selectedBadge {
-                badge.image
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 64, height: 64)
-                Text(badge.description)
-                Text(badge.title)
-                Text(badge.lockDescription)
-                Text(badge.rawValue)
-            } else {
-                Text("No matching badge")
-            }
-            
-            TextField("badge_name", text: $text)
-                .border(Color.gray, width: 1)
-                .padding(.horizontal, 30)
-            
-            Button("hit") {
-                selectedBadge = Badge(rawValue: text.uppercased())
-            }
-        }
-    }
-}
-
-#Preview {
-    BadgeTestView()
-}

--- a/playkuround-iOS/Models/UserEntity.swift
+++ b/playkuround-iOS/Models/UserEntity.swift
@@ -14,4 +14,6 @@ struct UserEntity {
     var landmarkRank: MyRank // 랜드마크별 랭킹
     var highestScore: Int
     var highestRank: String
+    var attendanceDays: Int
+    var profileBadge: String
 }

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -12,8 +12,8 @@ import SwiftUI
 final class HomeViewModel: ObservableObject {
     // User Profile
     @Published var userData: UserEntity = UserEntity(nickname: "", major: "",
-                                                     myRank: MyRank(score: 0, ranking: 0, profileBadge: "ATTENDANCE_1"),
-                                                     landmarkRank: MyRank(score: 0, ranking: 0, profileBadge: "ATTENDANCE_1"),
+                                                     myRank: MyRank(score: 0, ranking: 0, profileBadge: "NONE"),
+                                                     landmarkRank: MyRank(score: 0, ranking: 0, profileBadge: "NONE"),
                                                      highestScore: 0, highestRank: "")
     @Published var badgeList: [BadgeResponse] = []
     @Published var attendanceList: [String] = []
@@ -138,6 +138,8 @@ final class HomeViewModel: ObservableObject {
             switch result {
             case .success(_):
                 self.loadAttendance()
+                self.loadUserData()
+                self.loadBadge()
             case .failure(let error):
                 // TODO: 건국대학교 범위 외 혹은 다른 이유로 출석 실패 시 예외 처리 필요 (추후 APIManager 작업 시 구현)
                 print("Error in View: \(error)")

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -14,7 +14,7 @@ final class HomeViewModel: ObservableObject {
     @Published var userData: UserEntity = UserEntity(nickname: "", major: "",
                                                      myRank: MyRank(score: 0, ranking: 0, profileBadge: "NONE"),
                                                      landmarkRank: MyRank(score: 0, ranking: 0, profileBadge: "NONE"),
-                                                     highestScore: 0, highestRank: "")
+                                                     highestScore: 0, highestRank: "", attendanceDays: 0, profileBadge: "NONE")
     @Published var badgeList: [BadgeResponse] = []
     @Published var attendanceList: [String] = []
     
@@ -58,6 +58,8 @@ final class HomeViewModel: ObservableObject {
                             self.userData.major = response.response?.major ?? "-"
                             self.userData.highestScore = response.response?.highestScore ?? 0
                             self.userData.highestRank = response.response?.highestRank ?? "-"
+                            self.userData.attendanceDays = response.response?.attendanceDays ?? 0
+                            self.userData.profileBadge = response.response?.profileBadge ?? "NONE"
                         }
                     }
                 }

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -12,8 +12,8 @@ import SwiftUI
 final class HomeViewModel: ObservableObject {
     // User Profile
     @Published var userData: UserEntity = UserEntity(nickname: "", major: "",
-                                                     myRank: MyRank(score: 0, ranking: 0),
-                                                     landmarkRank: MyRank(score: 0, ranking: 0),
+                                                     myRank: MyRank(score: 0, ranking: 0, profileBadge: "ATTENDANCE_1"),
+                                                     landmarkRank: MyRank(score: 0, ranking: 0, profileBadge: "ATTENDANCE_1"),
                                                      highestScore: 0, highestRank: "")
     @Published var badgeList: [BadgeResponse] = []
     @Published var attendanceList: [String] = []

--- a/playkuround-iOS/Views/Home/Badge/BadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/BadgeView.swift
@@ -111,7 +111,7 @@ struct BadgeView: View {
     }
     
     func filterBadgeImage(for badge: Badge) -> Image {
-        if homeViewModel.badgeList.contains(where: { $0.description == badge.rawValue }) {
+        if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
             return badge.image
         } else {
             return Image(.badgeLock)

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -31,21 +31,22 @@ struct HomeView: View {
                     
                     HStack(spacing: 8) {
                         
-                        Image(.engineering)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 40, height: 40)
-                            .onTapGesture {
-                                // TODO: 추후 기능 구현 시
-                                // homeViewModel.transition(to: .badgeProfile)
-                            }
-                        
-                        Text(homeViewModel.userData.nickname + "님")
-                            .font(.neo18)
-                            .foregroundStyle(.kuText)
-                            .kerning(-0.41)
-                            .lineLimit(2)
-                            .padding(.trailing, 10)
+                        Group {
+                            Image(.engineering)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 40, height: 40)
+                            
+                            Text(homeViewModel.userData.nickname + "님")
+                                .font(.neo18)
+                                .foregroundStyle(.kuText)
+                                .kerning(-0.41)
+                                .lineLimit(2)
+                                .padding(.trailing, 10)
+                        }
+                        .onTapGesture {
+                            homeViewModel.transition(to: .badgeProfile)
+                        }
                         
                         Spacer()
                         

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -13,9 +13,6 @@ struct HomeView: View {
     @ObservedObject var mapViewModel: MapViewModel
     @State private var showStoryView: Bool = false
     
-    // 임시
-    @State private var isTestViewShowing: Bool = false
-    
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -84,9 +81,6 @@ struct HomeView: View {
                                         .kerning(-0.41)
                                 }
                                 .padding(.horizontal, 8)
-                            }
-                            .onTapGesture {
-                                isTestViewShowing = true
                             }
                     }
                     .padding(.top, shouldPadding ? 4 : 0)
@@ -214,9 +208,6 @@ struct HomeView: View {
             .onDisappear {
                 // 홈 뷰에서 벗어날 때 위치 업데이트 중지
                 mapViewModel.stopUpdatingLocation()
-            }
-            .sheet(isPresented: $isTestViewShowing) {
-                APIManagerTestView()
             }
         }
     }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -13,6 +13,9 @@ struct HomeView: View {
     @ObservedObject var mapViewModel: MapViewModel
     @State private var showStoryView: Bool = false
     
+    // 임시
+    @State private var isTestViewShowing: Bool = false
+    
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -77,7 +80,7 @@ struct HomeView: View {
                                 .padding(.horizontal, 8)
                             }
                             .onTapGesture {
-                                showStoryView.toggle()
+                                isTestViewShowing = true
                             }
                     }
                     .padding(.top, shouldPadding ? 4 : 0)
@@ -205,6 +208,9 @@ struct HomeView: View {
             .onDisappear {
                 // 홈 뷰에서 벗어날 때 위치 업데이트 중지
                 mapViewModel.stopUpdatingLocation()
+            }
+            .sheet(isPresented: $isTestViewShowing) {
+                APIManagerTestView()
             }
         }
     }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -35,10 +35,16 @@ struct HomeView: View {
                     HStack(spacing: 8) {
                         
                         Group {
-                            Image(.engineering)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 40, height: 40)
+                            if let badge = Badge(rawValue: homeViewModel.userData.profileBadge) {
+                                badge.image
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 40, height: 40)
+                            } else {
+                                Color.kuGray1.opacity(0.5)
+                                    .frame(width: 40, height: 40)
+                                    .cornerRadius(4)
+                            }
                             
                             Text(homeViewModel.userData.nickname + "님")
                                 .font(.neo18)

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
@@ -114,7 +114,8 @@ struct LandmarkRankingView: View {
                                             ForEach(Array(rankingList.enumerated()), id: \.offset) { index, rank in
                                                 TotalRankingRow(ranking: index + 1,
                                                                 rank: Ranking(nickname: rank.nickname, 
-                                                                              score: rank.score), badge: .COLLEGE_OF_ENGINEERING)
+                                                                              score: rank.score,
+                                                                              profileBadge: "ATTENDANCE_1"))
                                             }
                                         }
                                     }

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
@@ -115,7 +115,7 @@ struct LandmarkRankingView: View {
                                                 TotalRankingRow(ranking: index + 1,
                                                                 rank: Ranking(nickname: rank.nickname, 
                                                                               score: rank.score,
-                                                                              profileBadge: "ATTENDANCE_1"))
+                                                                              profileBadge: rank.profileBadge))
                                             }
                                         }
                                     }

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
@@ -131,11 +131,18 @@ struct LandmarkRankingView: View {
                                                     .frame(width: 40)
                                                     .padding(.trailing, 15)
                                                 
-                                                Image(.engineering)
-                                                    .resizable()
-                                                    .scaledToFit()
-                                                    .frame(width: 20, height: 20)
-                                                    .padding(.trailing, 10)
+                                                if let badge = Badge(rawValue: homeViewModel.userData.myRank.profileBadge) {
+                                                    badge.image
+                                                        .resizable()
+                                                        .scaledToFit()
+                                                        .frame(width: 20, height: 20)
+                                                        .padding(.trailing, 10)
+                                                } else {
+                                                    Color.kuGray1.opacity(0.5)
+                                                        .frame(width: 20, height: 20)
+                                                        .cornerRadius(4)
+                                                        .padding(.trailing, 10)
+                                                }
                                                 
                                                 Text("나")
                                                     .font(.pretendard15R)

--- a/playkuround-iOS/Views/Home/ProfileBadgeView.swift
+++ b/playkuround-iOS/Views/Home/ProfileBadgeView.swift
@@ -32,27 +32,18 @@ struct ProfileBadgeView: View {
                             .foregroundStyle(.kuText)
                             .padding(.bottom, 30)
                         
-                        /* if let selectedBadge = selectedBadge {
+                        if let selectedBadge = selectedBadge {
                             selectedBadge.image
                                 .resizable()
                                 .scaledToFit()
                                 .frame(width: 120, height: 120)
                                 .padding(.bottom, 10)
-                        } */
-                        
-                        // 임시 이미지
-                        Image(.engineering)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 120, height: 120)
-                            .padding(.bottom, 10)
-                        
-                        Text("USER_NICKNAME")
-                        // Text(homeViewModel.userData.nickname) // TODO: 실제 사용자 닉네임 대체
-                            .font(.neo18)
-                            .kerning(-0.41)
-                            .foregroundStyle(.kuText)
-                            .padding(.bottom, 30)
+                        } else {
+                            Color.kuGray1.opacity(0.5)
+                                .frame(width: 120, height: 120)
+                                .cornerRadius(5)
+                                .padding(.bottom, 10)
+                        }
                         
                         ScrollView(.vertical, content: {
                             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 4), spacing: 10) {
@@ -63,7 +54,7 @@ struct ProfileBadgeView: View {
                                             .aspectRatio(contentMode: .fit)
                                             .onTapGesture {
                                                 // TODO: 잠기지 않은 경우에만 변경되도록 조건 걸기
-                                                if homeViewModel.badgeList.contains(where: { $0.description == badge.rawValue }) {
+                                                if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
                                                     selectedBadge = badge
                                                 }
                                             }
@@ -80,7 +71,19 @@ struct ProfileBadgeView: View {
                         .padding(.horizontal, 40)
                         
                         Button {
-                            // TODO: upload selected user profile
+                            if let selectedBadge = selectedBadge {
+                                APIManager.callPOSTAPI(endpoint: .profileBadge, parameters: ["profileBadge": selectedBadge.rawValue]) { result in
+                                    switch result {
+                                    case .success(let data):
+                                        print("(success) /api/users/profile-badge: \(data)")
+                                        homeViewModel.loadUserData()
+                                        homeViewModel.loadTotalRanking()
+                                        homeViewModel.transition(to: .home)
+                                    case .failure(let error):
+                                        print("(fail) /api/users/profile-badge: \(error)")
+                                    }
+                                }
+                            }
                         } label: {
                             Image(.shortButtonBlue)
                                 .overlay {
@@ -95,11 +98,14 @@ struct ProfileBadgeView: View {
                     }
                 }
         }
+        .onAppear {
+            selectedBadge = Badge(rawValue: homeViewModel.userData.profileBadge)
+        }
     }
     
     func filterBadgeImage(for badge: Badge) -> Image {
         // 디자인 구현용으로 모두 열린 상태로 반환
-        if homeViewModel.badgeList.contains(where: { $0.description == badge.rawValue }) {
+        if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
             return badge.image
         } else {
             return Image(.badgeLock)

--- a/playkuround-iOS/Views/Home/ProfileBadgeView.swift
+++ b/playkuround-iOS/Views/Home/ProfileBadgeView.swift
@@ -45,6 +45,12 @@ struct ProfileBadgeView: View {
                                 .padding(.bottom, 10)
                         }
                         
+                        Text(homeViewModel.userData.nickname)
+                            .font(.neo18)
+                            .kerning(-0.41)
+                            .foregroundStyle(.kuText)
+                            .padding(.bottom, 30)
+                        
                         ScrollView(.vertical, content: {
                             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 4), spacing: 10) {
                                 ForEach(Badge.allCases, id: \.self) { badge in

--- a/playkuround-iOS/Views/Home/TotalRanking/TotalRankingRow.swift
+++ b/playkuround-iOS/Views/Home/TotalRanking/TotalRankingRow.swift
@@ -26,6 +26,12 @@ struct TotalRankingRow: View {
                     .scaledToFit()
                     .frame(width: 20, height: 20)
                     .padding(.trailing, 10)
+            } else {
+                // 예외 처리
+                Color.kuGray1.opacity(0.5)
+                    .frame(width: 20, height: 20)
+                    .cornerRadius(4)
+                    .padding(.trailing, 10)
             }
             
             Text(rank.nickname)

--- a/playkuround-iOS/Views/Home/TotalRanking/TotalRankingRow.swift
+++ b/playkuround-iOS/Views/Home/TotalRanking/TotalRankingRow.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct TotalRankingRow: View {
     let ranking: Int
     let rank: Ranking
-    let badge: Badge
     
     var body: some View {
         HStack(spacing: 0) {
@@ -21,11 +20,13 @@ struct TotalRankingRow: View {
                 .frame(width: 40)
                 .padding(.trailing, 15)
             
-            badge.image
-                .resizable()
-                .scaledToFit()
-                .frame(width: 20, height: 20)
-                .padding(.trailing, 10)
+            if let badge = Badge(rawValue: rank.profileBadge) {
+                badge.image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 20, height: 20)
+                    .padding(.trailing, 10)
+            }
             
             Text(rank.nickname)
                 .font(.pretendard15R)
@@ -46,5 +47,5 @@ struct TotalRankingRow: View {
 }
 
 #Preview {
-    TotalRankingRow(ranking: 1, rank: Ranking(nickname: "구라스", score: 123), badge: .COLLEGE_OF_ENGINEERING)
+    TotalRankingRow(ranking: 1, rank: Ranking(nickname: "구라스", score: 123, profileBadge: "ATTENDANCE_1"))
 }

--- a/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
+++ b/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
@@ -152,7 +152,7 @@ struct TotalRankingView: View {
                                         VStack(spacing: 12) {
                                             ForEach(Array(rankingList.enumerated()), id: \.offset) { index, rank in
                                                 TotalRankingRow(ranking: index + 1,
-                                                                rank: Ranking(nickname: rank.nickname, score: rank.score), badge: .COLLEGE_OF_ENGINEERING)
+                                                                rank: Ranking(nickname: rank.nickname, score: rank.score, profileBadge: "ATTENDANCE_1"))
                                             }
                                         }
                                     }

--- a/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
+++ b/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
@@ -195,11 +195,18 @@ struct TotalRankingView: View {
                                                     .frame(width: 40)
                                                     .padding(.trailing, 15)
                                                 
-                                                Image(.engineering)
-                                                    .resizable()
-                                                    .scaledToFit()
-                                                    .frame(width: 20, height: 20)
-                                                    .padding(.trailing, 10)
+                                                if let badge = Badge(rawValue: homeViewModel.userData.myRank.profileBadge) {
+                                                    badge.image
+                                                        .resizable()
+                                                        .scaledToFit()
+                                                        .frame(width: 20, height: 20)
+                                                        .padding(.trailing, 10)
+                                                } else {
+                                                    Color.kuGray1.opacity(0.5)
+                                                        .frame(width: 20, height: 20)
+                                                        .cornerRadius(4)
+                                                        .padding(.trailing, 10)
+                                                }
                                                 
                                                 Text("나")
                                                     .font(.pretendard15R)

--- a/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
+++ b/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
@@ -37,13 +37,22 @@ struct TotalRankingView: View {
                                             .overlay(alignment: .bottom) {
                                                 VStack {
                                                     if rankingList.indices.contains(1) {
-                                                        Image(.engineering)
-                                                            .resizable()
-                                                            .scaledToFit()
-                                                            .frame(width: 42, height: 42)
-                                                            .padding(.top, 20)
+                                                        let rank2 = rankingList[1]
                                                         
-                                                        Text(rankingList[1].nickname)
+                                                        if let badge = Badge(rawValue: rank2.profileBadge) {
+                                                            badge.image
+                                                                .resizable()
+                                                                .scaledToFit()
+                                                                .frame(width: 42, height: 42)
+                                                                .padding(.top, 20)
+                                                        } else {
+                                                            Color.kuGray1.opacity(0.5)
+                                                                .frame(width: 42, height: 42)
+                                                                .cornerRadius(5)
+                                                                .padding(.top, 20)
+                                                        }
+                                                        
+                                                        Text(rank2.nickname)
                                                             .font(.neo15)
                                                             .foregroundStyle(.kuText)
                                                             .padding(.bottom, 11)
@@ -53,7 +62,7 @@ struct TotalRankingView: View {
                                                             .frame(width: 60, height: 23)
                                                             .foregroundStyle(.kuBrown)
                                                             .overlay {
-                                                                Text("\(rankingList[1].score.decimalFormatter)점")
+                                                                Text("\(rank2.score.decimalFormatter)점")
                                                                     .font(.neo18)
                                                                     .kerning(-0.41)
                                                                     .foregroundStyle(.white)
@@ -67,13 +76,22 @@ struct TotalRankingView: View {
                                         Image(.rankingGold)
                                             .overlay(alignment: .bottom) {
                                                 VStack {
-                                                    Image(.engineering)
-                                                        .resizable()
-                                                        .scaledToFit()
-                                                        .frame(width: 42, height: 42)
-                                                        .padding(.top, 50)
+                                                    let rank1 = rankingList[0]
                                                     
-                                                    Text(rankingList[0].nickname)
+                                                    if let badge = Badge(rawValue: rank1.profileBadge) {
+                                                        badge.image
+                                                            .resizable()
+                                                            .scaledToFit()
+                                                            .frame(width: 42, height: 42)
+                                                            .padding(.top, 50)
+                                                    } else {
+                                                        Color.kuGray1.opacity(0.5)
+                                                            .frame(width: 42, height: 42)
+                                                            .cornerRadius(5)
+                                                            .padding(.top, 50)
+                                                    }
+                                                    
+                                                    Text(rank1.nickname)
                                                         .font(.neo15)
                                                         .foregroundStyle(.kuText)
                                                         .padding(.bottom, 11)
@@ -83,7 +101,7 @@ struct TotalRankingView: View {
                                                         .frame(width: 60, height: 23)
                                                         .foregroundStyle(.kuBrown)
                                                         .overlay {
-                                                            Text("\(rankingList[0].score.decimalFormatter)점")
+                                                            Text("\(rank1.score.decimalFormatter)점")
                                                                 .font(.neo18)
                                                                 .kerning(-0.41)
                                                                 .foregroundStyle(.white)
@@ -97,13 +115,22 @@ struct TotalRankingView: View {
                                             .overlay(alignment: .bottom) {
                                                 VStack {
                                                     if rankingList.indices.contains(2) {
-                                                        Image(.engineering)
-                                                            .resizable()
-                                                            .scaledToFit()
-                                                            .frame(width: 42, height: 42)
-                                                            .padding(.top, 20)
+                                                        let rank3 = rankingList[2]
                                                         
-                                                        Text(rankingList[2].nickname)
+                                                        if let badge = Badge(rawValue: rank3.profileBadge) {
+                                                            badge.image
+                                                                .resizable()
+                                                                .scaledToFit()
+                                                                .frame(width: 42, height: 42)
+                                                                .padding(.top, 20)
+                                                        } else {
+                                                            Color.kuGray1.opacity(0.5)
+                                                                .frame(width: 42, height: 42)
+                                                                .cornerRadius(5)
+                                                                .padding(.top, 20)
+                                                        }
+                                                        
+                                                        Text(rank3.nickname)
                                                             .font(.neo15)
                                                             .foregroundStyle(.kuText)
                                                             .padding(.bottom, 11)
@@ -113,7 +140,7 @@ struct TotalRankingView: View {
                                                             .frame(width: 60, height: 23)
                                                             .foregroundStyle(.kuBrown)
                                                             .overlay {
-                                                                Text("\(rankingList[2].score.decimalFormatter)점")
+                                                                Text("\(rank3.score.decimalFormatter)점")
                                                                     .font(.neo18)
                                                                     .kerning(-0.41)
                                                                     .foregroundStyle(.white)
@@ -152,7 +179,7 @@ struct TotalRankingView: View {
                                         VStack(spacing: 12) {
                                             ForEach(Array(rankingList.enumerated()), id: \.offset) { index, rank in
                                                 TotalRankingRow(ranking: index + 1,
-                                                                rank: Ranking(nickname: rank.nickname, score: rank.score, profileBadge: "ATTENDANCE_1"))
+                                                                rank: Ranking(nickname: rank.nickname, score: rank.score, profileBadge: rank.profileBadge))
                                             }
                                         }
                                     }


### PR DESCRIPTION
### 🐣Issue
closed #146 
<br/>

### 🐣Motivation
프로필 뱃지 선택 기능 구현 및 홈, 랭킹 프로필 이미지 기능 구현했습니다
<br/>

### 🐣Key Changes
1. APIManager에 Profile-Badge API Endpoint 처리 추가
2. APIManager APIResponse에 Rank, MyRank에 profileBadge 속성 추가
3. Badge enum rawValue를 ID로 변환 (서버에서 오는 rawValue가 string이라 매칭 필요)
4. 기존 랭킹뷰에 서버에서 개별 프로필 받아오도록 연결
5. loadUserData에서 프로필 뱃지도 받아옴
6. 홈에서 프로필 이미지 + 닉네임 그룹 누르면 프로필 뱃지 변경창으로 이동
7. 프로필 뱃지 변경 창에 받아온 뱃지로 설정
8. 프로필 뱃지 변경 기능 구현
<br/>

### 🐣Simulation
| 홈 (프로필 뱃지) | 전체 랭킹 | 랜드마크 랭킹 |
|--|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/ad2a2b7a-e2a7-4801-919d-ea4fcc336ae5"> | <img width="280px" src="https://github.com/user-attachments/assets/e50ea695-1458-4650-919d-3aa0a3cbbace"> | <img width="280px" src="https://github.com/user-attachments/assets/52bc55d7-7516-467e-bb86-26eef5c23613"> |

| 프로필 선택 창 (초기) | 다른 뱃지 선택 시 | 
|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/206b3409-f50b-4271-bc9f-33363f86902c"> | <img width="280px" src="https://github.com/user-attachments/assets/30912aff-71c3-41ad-bf98-da66734a365a"> |

| 프로필 뱃지 변경 시연 (영상) |
|--|
| <video width="300px" src="https://github.com/user-attachments/assets/c80eec20-c14e-4213-8026-aa0b3505cf09"> |

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
