### PR TITLE
[Fix] #172 - BadgeView 열린 뱃지 설명 나오지 않는 오류 수정

### DIFF
--- a/playkuround-iOS/Views/Home/Badge/BadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/BadgeView.swift
@@ -46,7 +46,7 @@ struct BadgeView: View {
                                             .onTapGesture {
                                                 self.showDetailBadge.toggle()
                                                 selectedBadge = badge
-                                                isSelectedBadgeLocked = !badgeList.contains { $0.description == badge.rawValue }
+                                                isSelectedBadgeLocked = !badgeList.contains { $0.name == badge.rawValue }
                                             }
                                     }
                                 }
@@ -74,7 +74,7 @@ struct BadgeView: View {
                                             .onTapGesture {
                                                 self.showDetailBadge.toggle()
                                                 selectedBadge = badge
-                                                isSelectedBadgeLocked = !badgeList.contains { $0.description == badge.rawValue }
+                                                isSelectedBadgeLocked = !badgeList.contains { $0.name == badge.rawValue }
                                             }
                                     }
                                 }


### PR DESCRIPTION
### 🐣Issue
closed #172 
<br/>

### 🐣Motivation
BadgeView에서 열린 뱃지 설명이 나오지 않는 오류를 수정했습니다
열린 뱃지, 잠긴 뱃지 모두 잠긴 화면이 나왔음
<br/>

### 🐣Key Changes
Badge enum의 rawValue를 name으로 변경 후 해당 부분 수정이 빠져있어 수정했습니다.
<br/>

```swift
.onTapGesture {
    self.showDetailBadge.toggle()
    selectedBadge = badge
    // $0.description → $0.name 으로 수정
    isSelectedBadgeLocked = !badgeList.contains { $0.name == badge.rawValue } 
}
```
<br/>

### 🐣Simulation
| 수정 후 |
|--|
| <video width="300px" src="https://github.com/user-attachments/assets/9d8b2a0a-7801-42e5-a3c1-dca9e20d945f"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
