### PR TITLE
[Fix] #162 - 게임 카운트다운에서 중단 오류 해결

### DIFF
--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -135,10 +135,10 @@ class GameViewModel: ObservableObject {
             withAnimation(.spring(duration: 0.1)) {
                 self.isCountdownViewPresented = true
             }
+            
+            // 카운트다운 시작
+            self.countdownProgress()
         }
-        
-        // 카운트다운 시작
-        self.countdownProgress()
     }
     
     final private func countdownProgress() {


### PR DESCRIPTION
### 🐣Issue
closed #162 
<br/>

### 🐣Motivation
게임 카운트다운 시 중단되는 오류를 수정했습니다
<br/>

### 🐣Key Changes
원인 분석 결과 DispatchQueue.main.async 는 별도의 스레드에서 실해되므로, 아래에서 `gameState = .countdown` 보다 `countdownProgress()` 함수가 먼저 실행되는 경우 오류가 발생한 것으로 파악되어 아래와 같이 일련으로 진행되도록 수정했습니다.

```swift
final func startCountdown() {
    DispatchQueue.main.async {
        self.gameState = .countdown
        
        withAnimation(.spring(duration: 0.1)) {
            self.isCountdownViewPresented = true
        }
        
        // 카운트다운 시작
        self.countdownProgress() // DispatchQueue.main 안으로 옮김
    }
}
```

모든 게임에 대해 각각 최소 10번씩 테스트해보았는데 문제가 발생하지 않았습니다.
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
혹시 오류 발생 시 알려주세요
<br/>

### 🐣Reference
X
<br/>
