### PR TITLE
[Fix] #174 - 건쏠지식 점수 로직 수정 (1.5v)

### DIFF
--- a/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
@@ -66,14 +66,17 @@ final class QuizGameViewModel: GameViewModel {
     }
     
     private func calculateScore() {
-        if correctAnswersCount >= 0 && correctAnswersCount <= 9 {
-            score = 10 * ( correctAnswersCount + 1 )
+        if correctAnswersCount == 0 {
+            score = 5
         }
-        else if correctAnswersCount >= 10 && correctAnswersCount <= 14 {
-            score = 10 * ( 2 * correctAnswersCount - 8 )
+        else if correctAnswersCount >= 1 && correctAnswersCount <= 15 {
+            score = 10 * correctAnswersCount
         }
-        else if correctAnswersCount == 15 {
-            score = 250
+        else if correctAnswersCount >= 16 && correctAnswersCount <= 24 {
+            score = 10 * ( 2 * correctAnswersCount - 14 )
+        }
+        else if correctAnswersCount >= 25 {
+            score = 400
         }
     }
 }

--- a/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/QuizGame/QuizGameViewModel.swift
@@ -72,10 +72,10 @@ final class QuizGameViewModel: GameViewModel {
         else if correctAnswersCount >= 1 && correctAnswersCount <= 15 {
             score = 10 * correctAnswersCount
         }
-        else if correctAnswersCount >= 16 && correctAnswersCount <= 24 {
+        else if correctAnswersCount >= 16 && correctAnswersCount <= 25 {
             score = 10 * ( 2 * correctAnswersCount - 14 )
         }
-        else if correctAnswersCount >= 25 {
+        else if correctAnswersCount >= 26 {
             score = 400
         }
     }


### PR DESCRIPTION
### 🐣Issue
closed  #174 
<br/>

### 🐣Motivation
- 1.5v 패치된 버전의 건쏠지식 점수 로직 수정 완료했습니다. 
<br/>

### 🐣Key Changes
<img width="408" alt="Screenshot 2024-08-24 at 2 30 37 AM" src="https://github.com/user-attachments/assets/1f39c750-2d64-40b1-bb7d-b039aac9bd20">

0개 맞췄을 때 -> 5점
1 ~ 15개 맞췄을 때 -> 10 * 문제 수
16 ~ 25개 맞췄을 때 -> 10 * (2 * 문제수 - 14)
26개 이상 맞췄을 때 -> 250

으로 케이스 구분하여 점수 계산 로직 수정해두었습니다!
<br/>

### 🐣Simulation

### 🐣To Reviewer
- 추후에 사용자가 모든 문제를 다 맞췄을 때 나오는 결과 로직이나 화면 뷰가 있어야 할 것 같다는 생각이 들었습니다 .. 어떻게 하는 게 좋을까요 하하
<br/>

### 🐣Reference

<br/>
