### PR TITLE
[Fix] #186 - 닉네임 등록뷰에서 다음 버튼 클릭 시 효과음 나올 수 있도록 수정

### DIFF
--- a/playkuround-iOS/Views/Register/RegisterNickname.swift
+++ b/playkuround-iOS/Views/Register/RegisterNickname.swift
@@ -21,6 +21,8 @@ struct RegisterNickname: View {
     // 서버 요청 대기
     @State private var isLoading: Bool = false
     
+    private let soundManager = SoundManager.shared
+    
     var body: some View {
         ZStack {
             Color.kuBackground.ignoresSafeArea(.all)
@@ -125,6 +127,7 @@ struct RegisterNickname: View {
                         }
                     }
                     .onTapGesture {
+                        soundManager.playSound(sound: .buttonClicked)
                         // 닉네임 올바른지 검사
                         if !isNicknameChecked && isNicknameVaild && nickname.count >= 2 {
                             isLoading = true


### PR DESCRIPTION
### 🐣Issue
closed #186 
<br/>

### 🐣Motivation
- 사운드 작업에서 누락되었던 닉네임 등록뷰에서 다음 버튼 클릭 시 효과음을 추가적으로 적용했습니다. 
<br/>

### 🐣Key Changes

<br/>

### 🐣Simulation


<br/>

### 🐣To Reviewer

<br/>

### 🐣Reference

<br/>
