### PR TITLE
[Fix] #195 - TestFlight 업로드 시 수출규정 관련 문서 누락 메시지 해결

### DIFF
--- a/playkuround-iOS/Info.plist
+++ b/playkuround-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
### 🐣Issue
closed #195 
<br/>

### 🐣Motivation
- TestFlight 업로드 시 수출규정 관련 문서 누락 메시지 해결을 위해 info.plist 파일 수정했습니다. 
<br/>

### 🐣Key Changes
- Test Flight 업로드 시 **missing Compliance** 라는 경고로 인해 초대하기가 번거로워 info.plist애 해당 키를 추가하여 수출 시 암호화를 사용하지 않도록 설정했습니다. 
<br/>

### 🐣Simulation
<br/>

### 🐣To Reviewer

<br/>

### 🐣Reference

<br/>
