### PR TITLE
[Fix] #199 - 뱃지 프로필 선택 창 잠긴 뱃지 숨기기 작업

### DIFF
--- a/playkuround-iOS/Views/Home/Badge/ProfileBadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/ProfileBadgeView.swift
@@ -54,21 +54,23 @@ struct ProfileBadgeView: View {
                         ScrollView(.vertical, content: {
                             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 4), spacing: 10) {
                                 ForEach(Badge.allCases, id: \.self) { badge in
-                                    ZStack {
-                                        filterBadgeImage(for: badge)
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fit)
-                                            .onTapGesture {
-                                                // TODO: 잠기지 않은 경우에만 변경되도록 조건 걸기
-                                                if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
-                                                    selectedBadge = badge
-                                                }
-                                            }
-                                        
-                                        if badge == selectedBadge {
-                                            Image(.badgeChecked)
+                                    if let badgeImage = filterBadgeImage(for: badge) {
+                                        ZStack {
+                                            badgeImage
                                                 .resizable()
                                                 .aspectRatio(contentMode: .fit)
+                                                .onTapGesture {
+                                                    // TODO: 잠기지 않은 경우에만 변경되도록 조건 걸기
+                                                    if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
+                                                        selectedBadge = badge
+                                                    }
+                                                }
+                                            
+                                            if badge == selectedBadge {
+                                                Image(.badgeChecked)
+                                                    .resizable()
+                                                    .aspectRatio(contentMode: .fit)
+                                            }
                                         }
                                     }
                                 }
@@ -115,11 +117,11 @@ struct ProfileBadgeView: View {
         }
     }
     
-    func filterBadgeImage(for badge: Badge) -> Image {
+    func filterBadgeImage(for badge: Badge) -> Image? {
         if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
             return badge.image
         } else {
-            return Image(.badgeLock)
+            return nil
         }
     }
 }


### PR DESCRIPTION
### 🐣Issue
closed #199 
<br/>

### 🐣Motivation
뱃지 프로필 선택 창에서 잠긴 뱃지는 숨겨지도록 수정했습니다
<br/>

### 🐣Key Changes
뱃지 프로필 선택 창에서 잠긴 뱃지는 보이지 않고 열려 있는 뱃지만 보입니다
<br/>

```swift
ForEach(Badge.allCases, id: \.self) { badge in
    if let badgeImage = filterBadgeImage(for: badge) { // 잠기지 않은 뱃지만, 잠겨져 있으면 nil
        ZStack {
            badgeImage
                .resizable()
                .aspectRatio(contentMode: .fit)
                .onTapGesture {
                    // TODO: 잠기지 않은 경우에만 변경되도록 조건 걸기
                    if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
                        selectedBadge = badge
                    }
                }
            
            if badge == selectedBadge {
                Image(.badgeChecked)
                    .resizable()
                    .aspectRatio(contentMode: .fit)
            }
        }
    }
}

// ...

func filterBadgeImage(for badge: Badge) -> Image? {
    if homeViewModel.badgeList.contains(where: { $0.name == badge.rawValue }) {
        return badge.image
    } else {
        return nil // 잠긴 뱃지는 nil 반환
    }
}
```
<br/>

### 🐣Simulation
| 수정된 뷰 |
|--|
| <img width="340px" alt="image" src="https://github.com/user-attachments/assets/a70a85d8-ee48-4ed1-a0f7-d09b17106fd8"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
x
<br/>
