### PR TITLE
[Feat] #198 - 서버 공지사항 API 연동 및 새 공지 기능 구현

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		0C5979B52BAB215300E8156D /* RegisterMajorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979B42BAB215300E8156D /* RegisterMajorView.swift */; };
 		0C5979B82BAB25EE00E8156D /* serviceKorean.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C5979B72BAB25EE00E8156D /* serviceKorean.txt */; };
 		0C5979BC2BAB26A800E8156D /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979BB2BAB26A800E8156D /* TermsView.swift */; };
+		0C5FC0852C7EB1C8009ABA64 /* QuizData.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FC0842C7EB1C8009ABA64 /* QuizData.json */; };
+		0C5FC0872C7EB1D8009ABA64 /* EventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FC0862C7EB1D5009ABA64 /* EventManager.swift */; };
 		0C6396E82BAB4BB8008E046F /* RegisterNickname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6396E72BAB4BB8008E046F /* RegisterNickname.swift */; };
 		0C691EB12BBD9FF2004021F1 /* TimerGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */; };
 		0C691EB32BBDA028004021F1 /* TimerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C691EB22BBDA028004021F1 /* TimerState.swift */; };
@@ -33,7 +35,6 @@
 		0C6B77F62BABCC8F0033CEEF /* locationKorean.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C6B77F52BABCC8F0033CEEF /* locationKorean.txt */; };
 		0C6B77F82BABCCCD0033CEEF /* privacyKorean.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C6B77F72BABCCCD0033CEEF /* privacyKorean.txt */; };
 		0C6C36CA2C0339960069EE06 /* MotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6C36C92C0339960069EE06 /* MotionManager.swift */; };
-		0C6F75CC2C7CD2750075FAC3 /* QuizData.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C6F75CB2C7CD2750075FAC3 /* QuizData.json */; };
 		0C6F75D02C7CDFB80075FAC3 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 0C6F75CF2C7CDFB80075FAC3 /* Localizable.xcstrings */; };
 		0C6F75D62C7CEA280075FAC3 /* LandmarkDescriptionEnglish.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C6F75D52C7CEA200075FAC3 /* LandmarkDescriptionEnglish.json */; };
 		0C6F75D82C7CEA2A0075FAC3 /* LandmarkDescriptionChinese.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C6F75D72C7CEA2A0075FAC3 /* LandmarkDescriptionChinese.json */; };
@@ -170,6 +171,8 @@
 		0C5979B42BAB215300E8156D /* RegisterMajorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterMajorView.swift; sourceTree = "<group>"; };
 		0C5979B72BAB25EE00E8156D /* serviceKorean.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = serviceKorean.txt; sourceTree = "<group>"; };
 		0C5979BB2BAB26A800E8156D /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
+		0C5FC0842C7EB1C8009ABA64 /* QuizData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = QuizData.json; sourceTree = "<group>"; };
+		0C5FC0862C7EB1D5009ABA64 /* EventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventManager.swift; sourceTree = "<group>"; };
 		0C6396E72BAB4BB8008E046F /* RegisterNickname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNickname.swift; sourceTree = "<group>"; };
 		0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerGameViewModel.swift; sourceTree = "<group>"; };
 		0C691EB22BBDA028004021F1 /* TimerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerState.swift; sourceTree = "<group>"; };
@@ -183,7 +186,6 @@
 		0C6B77F52BABCC8F0033CEEF /* locationKorean.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = locationKorean.txt; sourceTree = "<group>"; };
 		0C6B77F72BABCCCD0033CEEF /* privacyKorean.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = privacyKorean.txt; sourceTree = "<group>"; };
 		0C6C36C92C0339960069EE06 /* MotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionManager.swift; sourceTree = "<group>"; };
-		0C6F75CB2C7CD2750075FAC3 /* QuizData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = QuizData.json; sourceTree = "<group>"; };
 		0C6F75CF2C7CDFB80075FAC3 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		0C6F75D52C7CEA200075FAC3 /* LandmarkDescriptionEnglish.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LandmarkDescriptionEnglish.json; sourceTree = "<group>"; };
 		0C6F75D72C7CEA2A0075FAC3 /* LandmarkDescriptionChinese.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LandmarkDescriptionChinese.json; sourceTree = "<group>"; };
@@ -345,7 +347,7 @@
 				0C6F75D42C7CEA1B0075FAC3 /* English */,
 				0C6F75D32C7CEA120075FAC3 /* Chinese */,
 				C98BDC3C2C75C60000ACBB46 /* LandmarkDescription.json */,
-				0C6F75CB2C7CD2750075FAC3 /* QuizData.json */,
+				0C5FC0842C7EB1C8009ABA64 /* QuizData.json */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -615,6 +617,7 @@
 		C918F4032BA7148800C0BFDA /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				0C5FC0862C7EB1D5009ABA64 /* EventManager.swift */,
 				0C6AA4BA2BA4A33E0032AB24 /* NetworkManager.swift */,
 				0C6AA4BC2BA553D80032AB24 /* APIManager.swift */,
 				0C6AA4D02BA6DA340032AB24 /* TokenManager.swift */,
@@ -960,7 +963,6 @@
 				0C8C29542C7E1BA80071C005 /* locationEnglish.txt in Resources */,
 				C98078982BA870E400C04B2D /* timerIncorrect.mp3 in Resources */,
 				C98078BF2BA872A300C04B2D /* duckkuClicked.mp3 in Resources */,
-				0C6F75CC2C7CD2750075FAC3 /* QuizData.json in Resources */,
 				0C6B77F62BABCC8F0033CEEF /* locationKorean.txt in Resources */,
 				C98078AA2BA871A000C04B2D /* cardCorrect.mp3 in Resources */,
 				C98078C42BA872DF00C04B2D /* moonClicked.mp3 in Resources */,
@@ -981,6 +983,7 @@
 				C980789D2BA8712700C04B2D /* cupidGoodOrPerfect.mp3 in Resources */,
 				C9F694EC2BA3251B009A8762 /* Assets.xcassets in Resources */,
 				C953D2F62BA47B0700318869 /* NeoDunggeunmoPro-Regular.ttf in Resources */,
+				0C5FC0852C7EB1C8009ABA64 /* QuizData.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1086,6 +1089,7 @@
 				B9018CFD2BDB611F00BC819C /* CupidGameViewModel.swift in Sources */,
 				0CBB05902BB07A1400EB56BE /* MapViewModel.swift in Sources */,
 				0CFFF0BE2C08EB1B00397875 /* HomeViewModel.swift in Sources */,
+				0C5FC0872C7EB1D8009ABA64 /* EventManager.swift in Sources */,
 				C97987462BC3D91600BB3698 /* QuizState.swift in Sources */,
 				B9406DE92C42DABC004FEDC2 /* StoryView.swift in Sources */,
 				0CA193562BB5ABEB007C04B1 /* RequestPermissionView.swift in Sources */,

--- a/playkuround-iOS/Extensions/Managers/APIManager.swift
+++ b/playkuround-iOS/Extensions/Managers/APIManager.swift
@@ -69,6 +69,8 @@ final class APIManager {
         case gameScore = "/api/users/game-score"
         // 해당 닉네임이 사용 가능한지 체크
         case availability = "/api/users/availability"
+        // 이벤트(공지) 조회
+        case events = "/api/events"
     }
     
     // POST 요청 API Collections
@@ -216,6 +218,14 @@ final class APIManager {
                 else if endpoint == .availability {
                     print("\n===== /api/users/availability ====\n")
                     let apiResponse = try decoder.decode(BoolResponse.self, from: data)
+                    print("\(apiResponse)")
+                    completion(.success(apiResponse))
+                }
+                
+                // 공지 이벤트 /api/events
+                else if endpoint == .events {
+                    print("\n===== /api/events ====\n")
+                    let apiResponse = try decoder.decode(EventAPIResponse.self, from: data)
                     print("\(apiResponse)")
                     completion(.success(apiResponse))
                 }
@@ -657,6 +667,17 @@ struct APIManagerTestView: View {
                                 }
                             }
                         }
+                        
+                        Button("이벤트 받아오기 - /api/events") {
+                            APIManager.callGETAPI(endpoint: .events) { result in
+                                switch result {
+                                case .success(let data):
+                                    print("/api/events data: \(data)")
+                                case .failure(let error):
+                                    print("/api/events error: \(error)")
+                                }
+                            }
+                        }
                     }
                     
                     // MARK: - POST
@@ -880,5 +901,20 @@ struct NotificationVariableResponse: Codable {
 struct NotificationAPIResponse: Codable {
     let isSuccess: Bool
     let response: [NotificationVariableResponse]?
+    let errorResponse: ErrorResponse?
+}
+
+// 공지 알림 (/api/events)
+struct Event: Codable {
+    let id: Int
+    let title: String
+    let imageUrl: String?
+    let description: String?
+    let referenceUrl: String?
+}
+
+struct EventAPIResponse: Codable {
+    let isSuccess: Bool
+    let response: [Event]?
     let errorResponse: ErrorResponse?
 }

--- a/playkuround-iOS/Extensions/Managers/EventManager.swift
+++ b/playkuround-iOS/Extensions/Managers/EventManager.swift
@@ -1,0 +1,31 @@
+//
+//  EventManager.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 8/28/24.
+//
+
+import Foundation
+
+final class EventManager {
+    // Static Class로 사용
+    static let shared = EventManager()
+    
+    // 확인한 공지 중 가장 큰 ID를 갱신
+    func updateEventID(_ notiID: Int) -> Bool {
+        let topID = UserDefaults.standard.integer(forKey: "NOTI_TOP_ID")
+        print("topID: \(topID), newID: \(notiID)")
+        
+        if topID < notiID {
+            UserDefaults.standard.setValue(notiID, forKey: "NOTI_TOP_ID")
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    // 확인한 공지 중 가장 큰 ID를 반환
+    func getTopEventID() -> Int {
+        return UserDefaults.standard.integer(forKey: "NOTI_TOP_ID")
+    }
+}

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -57,13 +57,7 @@
     "+ %@" : {
       "shouldTranslate" : false
     },
-    "10초를 맞춰봐" : {
-      "shouldTranslate" : false
-    },
     "access" : {
-      "shouldTranslate" : false
-    },
-    "AdventureView 열기" : {
       "shouldTranslate" : false
     },
     "authVerify" : {
@@ -2203,9 +2197,6 @@
         }
       }
     },
-    "MOON을 점령해" : {
-      "shouldTranslate" : false
-    },
     "MyPage.BugURL" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2874,6 +2865,9 @@
           }
         }
       }
+    },
+    "new!" : {
+
     },
     "No Network Connection" : {
       "shouldTranslate" : false
@@ -3709,9 +3703,6 @@
     "가장 가까운 랜드마크 - /api/landmarks" : {
       "shouldTranslate" : false
     },
-    "건쏠지식" : {
-      "shouldTranslate" : false
-    },
     "게임" : {
       "shouldTranslate" : false
     },
@@ -3751,12 +3742,6 @@
       "shouldTranslate" : false
     },
     "단과대학 및 학과 (Section)" : {
-      "shouldTranslate" : false
-    },
-    "덕쿠를 잡아라!" : {
-      "shouldTranslate" : false
-    },
-    "덕큐피트" : {
       "shouldTranslate" : false
     },
     "랜드마크 TOP100 - /api/scores/rank/25" : {
@@ -3801,6 +3786,9 @@
     "이 게임 최고 점수: %lld" : {
       "shouldTranslate" : false
     },
+    "이벤트 받아오기 - /api/events" : {
+
+    },
     "인증 코드 확인 - /api/auth/emails" : {
       "shouldTranslate" : false
     },
@@ -3810,16 +3798,10 @@
     "인증코드 재발급 - /api/auth/reissue" : {
       "shouldTranslate" : false
     },
-    "일감호에서 살아남기" : {
-      "shouldTranslate" : false
-    },
     "일시정지" : {
       "shouldTranslate" : false
     },
     "종합 TOP100 - /api/scores/rank" : {
-      "shouldTranslate" : false
-    },
-    "책 뒤집기" : {
       "shouldTranslate" : false
     },
     "최고 점수 불러오기" : {
@@ -3841,9 +3823,6 @@
       "shouldTranslate" : false
     },
     "타이머 초기화" : {
-      "shouldTranslate" : false
-    },
-    "탐험" : {
       "shouldTranslate" : false
     },
     "탐험하기 - /api/adventures" : {

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -1303,6 +1303,29 @@
         }
       }
     },
+    "Home.ToastMessage.NoEvent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no Notices and Events"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공지사항이 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有公告"
+          }
+        }
+      }
+    },
     "Home.ToastMessage.NoNearLandmark" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2866,9 +2889,6 @@
         }
       }
     },
-    "new!" : {
-
-    },
     "No Network Connection" : {
       "shouldTranslate" : false
     },
@@ -3787,7 +3807,7 @@
       "shouldTranslate" : false
     },
     "이벤트 받아오기 - /api/events" : {
-
+      "shouldTranslate" : false
     },
     "인증 코드 확인 - /api/auth/emails" : {
       "shouldTranslate" : false

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -476,7 +476,7 @@ final class HomeViewModel: ObservableObject {
     
     // 공지 받아오기
     func loadEvents() {
-        /* APIManager.callGETAPI(endpoint: .events) { result in
+        APIManager.callGETAPI(endpoint: .events) { result in
             switch result {
             case .success(let data):
                 if let apiResponse = data as? EventAPIResponse {
@@ -501,24 +501,7 @@ final class HomeViewModel: ObservableObject {
                     self.eventList = []
                 }
             }
-        } */
-        self.eventList = [Event(id: 1,
-                                title: "녹색지대 부스 안내",
-                                imageUrl: "https://shorturl.at/6hQj6",
-                                description: "5/22~24 (수,목) 녹색지대 플레이쿠라운드 팝업스토어 운영",
-                                referenceUrl: "https://www.instagram.com/p/C7LuzJehez-/?utm_source=ig_web_copy_link"),
-                          Event(id: 2,
-                                title: "녹색지대 부스 안내",
-                                imageUrl: "https://shorturl.at/6hQj6",
-                                description: nil,
-                                referenceUrl: nil), // "https://www.instagram.com/p/C7LuzJehez-/?utm_source=ig_web_copy_link"),
-                          Event(id: 3,
-                                title: "녹색지대 부스 안내",
-                                imageUrl: nil,
-                                description: "5/22~24 (수,목) 녹색지대 플레이쿠라운드 팝업스토어 운영",
-                                referenceUrl: nil) // "https://www.instagram.com/p/C7LuzJehez-/?utm_source=ig_web_copy_link")
-        ]
-        self.updateIsNewEvent()
+        }
     }
     
     // 이벤트를 인덱스로 가져옴

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -36,6 +36,10 @@ final class HomeViewModel: ObservableObject {
     @Published var gameName: String = ""
     @Published var isStartButtonEnabled: Bool = false
     
+    // 공지 이벤트
+    @Published var eventList: [Event] = []
+    @Published var isNewEvent: Bool = false
+    
     private let gameNames: [String]
     private var currentIndex = 0
     private var delayMillis: TimeInterval = 0.05
@@ -467,6 +471,90 @@ final class HomeViewModel: ObservableObject {
             return gameNamesOriginal[index]
         } else {
             return nil
+        }
+    }
+    
+    // 공지 받아오기
+    func loadEvents() {
+        /* APIManager.callGETAPI(endpoint: .events) { result in
+            switch result {
+            case .success(let data):
+                if let apiResponse = data as? EventAPIResponse {
+                    if let eventList = apiResponse.response {
+                        DispatchQueue.main.async {
+                            self.eventList = eventList
+                            self.updateIsNewEvent()
+                        }
+                    } else {
+                        DispatchQueue.main.async {
+                            self.eventList = []
+                        }
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        self.eventList = []
+                    }
+                }
+            case .failure(let error):
+                print(error)
+                DispatchQueue.main.async {
+                    self.eventList = []
+                }
+            }
+        } */
+        self.eventList = [Event(id: 1,
+                                title: "녹색지대 부스 안내",
+                                imageUrl: "https://shorturl.at/6hQj6",
+                                description: "5/22~24 (수,목) 녹색지대 플레이쿠라운드 팝업스토어 운영",
+                                referenceUrl: "https://www.instagram.com/p/C7LuzJehez-/?utm_source=ig_web_copy_link"),
+                          Event(id: 2,
+                                title: "녹색지대 부스 안내",
+                                imageUrl: "https://shorturl.at/6hQj6",
+                                description: nil,
+                                referenceUrl: nil), // "https://www.instagram.com/p/C7LuzJehez-/?utm_source=ig_web_copy_link"),
+                          Event(id: 3,
+                                title: "녹색지대 부스 안내",
+                                imageUrl: nil,
+                                description: "5/22~24 (수,목) 녹색지대 플레이쿠라운드 팝업스토어 운영",
+                                referenceUrl: nil) // "https://www.instagram.com/p/C7LuzJehez-/?utm_source=ig_web_copy_link")
+        ]
+        self.updateIsNewEvent()
+    }
+    
+    // 이벤트를 인덱스로 가져옴
+    func getEventByIndex(_ index: Int) -> Event? {
+        if index < 0 || index >= eventList.count {
+            return nil
+        }
+        
+        return eventList[index]
+    }
+    
+    func viewEvent(id: Int) {
+        // 조회 처리
+        if EventManager.shared.updateEventID(id) {
+            print("event id is updated")
+        }
+        self.updateIsNewEvent()
+    }
+    
+    // new 이벤트가 있는지 검사
+    func updateIsNewEvent() {
+        var maxID: Int = -1
+        let topID = EventManager.shared.getTopEventID()
+        
+        for event in self.eventList {
+            if event.id > maxID {
+                maxID = event.id
+            }
+        }
+        
+        DispatchQueue.main.async {
+            if maxID > topID {
+                self.isNewEvent = true
+            } else {
+                self.isNewEvent = false
+            }
         }
     }
 }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -126,7 +126,19 @@ struct HomeView: View {
                                 soundManager.playSound(sound: .buttonClicked)
                             } label: {
                                 Image(.notiButton)
+                                    .overlay {
+                                        if homeViewModel.isNewEvent {
+                                            Text("new!")
+                                                .font(.neo15)
+                                                .foregroundColor(.kuTimebarRed)
+                                                .kerning(-0.41)
+                                                .textRainStroke()
+                                                .offset(x: 18, y: -18)
+                                        }
+                                    }
                             }
+                            .disabled(homeViewModel.eventList.isEmpty)
+                            .opacity(homeViewModel.eventList.isEmpty ? 0.5 : 1)
                             
                             Spacer()
                         }
@@ -232,6 +244,7 @@ struct HomeView: View {
                 homeViewModel.loadBadge()
                 homeViewModel.loadTotalRanking()
                 homeViewModel.loadAttendance()
+                homeViewModel.loadEvents()
                 
                 GAManager.shared.logScreenEvent(.HomeView)
             }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -122,13 +122,17 @@ struct HomeView: View {
                             }
                             
                             Button {
-                                homeViewModel.transition(to: .notification)
                                 soundManager.playSound(sound: .buttonClicked)
+                                if homeViewModel.eventList.isEmpty {
+                                    viewModel.openToastMessageView(message: NSLocalizedString("Home.ToastMessage.NoEvent", comment: ""))
+                                } else {
+                                    homeViewModel.transition(to: .notification)
+                                }
                             } label: {
                                 Image(.notiButton)
                                     .overlay {
                                         if homeViewModel.isNewEvent {
-                                            Text("new!")
+                                            Text("Home.Badge.New")
                                                 .font(.neo15)
                                                 .foregroundColor(.kuTimebarRed)
                                                 .kerning(-0.41)
@@ -137,8 +141,6 @@ struct HomeView: View {
                                         }
                                     }
                             }
-                            .disabled(homeViewModel.eventList.isEmpty)
-                            .opacity(homeViewModel.eventList.isEmpty ? 0.5 : 1)
                             
                             Spacer()
                         }

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -149,7 +149,7 @@ struct HomeView: View {
                     Spacer()
                     
                     // 임시 구현
-                    Menu {
+                    /* Menu {
                         Section("탐험") {
                             Button("AdventureView 열기") {
                                 let latitude = mapViewModel.userLatitude
@@ -194,9 +194,9 @@ struct HomeView: View {
                                     .kerning(-0.41)
                             }
                     }
-                    .padding(.bottom, shouldPadding ? 60 : 70)
+                    .padding(.bottom, shouldPadding ? 60 : 70) */
                     
-                    /* Button {
+                    Button {
                         let latitude = mapViewModel.userLatitude
                         let longitude = mapViewModel.userLongitude
                         
@@ -210,7 +210,7 @@ struct HomeView: View {
                                     .kerning(-0.41)
                             }
                     }
-                    .padding(.bottom, shouldPadding ? 60 : 70) */
+                    .padding(.bottom, shouldPadding ? 60 : 70)
                 }
                 .padding(.top, shouldPadding ? 12 : 9)
                 

--- a/playkuround-iOS/Views/Home/Notification/NotificationView.swift
+++ b/playkuround-iOS/Views/Home/Notification/NotificationView.swift
@@ -58,7 +58,7 @@ struct NotificationView: View {
                                             .kerning(-0.41)
                                         
                                         if isNew {
-                                            Text("new!")
+                                            Text("Home.Badge.New")
                                                 .font(.neo15)
                                                 .foregroundColor(.kuTimebarRed)
                                                 .kerning(-0.41)


### PR DESCRIPTION
### 🐣Issue
closed #198 
<br/>

### 🐣Motivation
서버 공지사항 API 연동 및 새 공지 기능 구현했습니다
<br/>

### 🐣Key Changes
- APIManager에 events 엔드포인트 처리 구현
- `EventManager` 만들어 확인한 공지 중 가장 큰 ID를 저장, 비교, 업데이트
- 공지사항 확인 시 조회 처리, 가장 큰 ID를 `EventManager`에 저장
<br/>

```swift
homeViewModel.loadEvents() // 이벤트 받아옴
homeViewModel.updateIsNewEvent() // 새 이벤트 존재하는지 검사 (전체)
homeViewModel.getEventByIndex(_ index: Int) -> Event? // 특정 index로 이벤트 가져오기 (id X)
homeViewModel.viewEvent(id: Int) // 특정 이벤트 조회 처리 (이벤트 조회하고 닫을 때 적용)
```
<br/>

### 🐣Simulation
| 새 공지 (홈) | 새 공지 | 이벤트 없는 경우 |
|--|--|--|
| <img width="300px" src="https://github.com/user-attachments/assets/85eef868-4a37-4b96-aa75-494bd2acde02"> | <img width="300px" src="https://github.com/user-attachments/assets/898d05ab-92dd-4d19-94a2-fd16e95acb30"> | <img width="300px" src="https://github.com/user-attachments/assets/7015e1b5-fa26-451b-bc2d-b50d5d005825"> |
- 이벤트 없는 경우 토스트메시지로 처리
<br/>

| 시연 영상 |
|--|
| <video width="300px" src="https://github.com/user-attachments/assets/dc6e41b5-3215-4172-9f19-52a130825cc8"> |
- 앱 접속 시 지금까지 조회했던 가장 높은 ID보다 큰 ID를 갖는 공지가 있을 경우 NEW! 띄움
- 공지창을 닫거나, 공지 이동 시 조회 처리 (열릴 때 처리하면 NEW가 안뜸)
<br>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
