### PR TITLE
[Feat] #202 - 심사용 예외 처리 및 릴리즈 준비 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ xcuserdata/
 .DS_Store
 
 QuizData.json
+Admin.json

--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -20,8 +20,10 @@
 		0C5979B52BAB215300E8156D /* RegisterMajorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979B42BAB215300E8156D /* RegisterMajorView.swift */; };
 		0C5979B82BAB25EE00E8156D /* serviceKorean.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C5979B72BAB25EE00E8156D /* serviceKorean.txt */; };
 		0C5979BC2BAB26A800E8156D /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5979BB2BAB26A800E8156D /* TermsView.swift */; };
-		0C5FC0852C7EB1C8009ABA64 /* QuizData.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FC0842C7EB1C8009ABA64 /* QuizData.json */; };
 		0C5FC0872C7EB1D8009ABA64 /* EventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FC0862C7EB1D5009ABA64 /* EventManager.swift */; };
+		0C5FC0892C7EDD06009ABA64 /* QuizData.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FC0882C7EDD06009ABA64 /* QuizData.json */; };
+		0C5FC08D2C7EE092009ABA64 /* AdminAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FC08C2C7EE08E009ABA64 /* AdminAccount.swift */; };
+		0C5FC08F2C7EE0EB009ABA64 /* Admin.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FC08E2C7EE0E7009ABA64 /* Admin.json */; };
 		0C6396E82BAB4BB8008E046F /* RegisterNickname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6396E72BAB4BB8008E046F /* RegisterNickname.swift */; };
 		0C691EB12BBD9FF2004021F1 /* TimerGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */; };
 		0C691EB32BBDA028004021F1 /* TimerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C691EB22BBDA028004021F1 /* TimerState.swift */; };
@@ -171,8 +173,10 @@
 		0C5979B42BAB215300E8156D /* RegisterMajorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterMajorView.swift; sourceTree = "<group>"; };
 		0C5979B72BAB25EE00E8156D /* serviceKorean.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = serviceKorean.txt; sourceTree = "<group>"; };
 		0C5979BB2BAB26A800E8156D /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
-		0C5FC0842C7EB1C8009ABA64 /* QuizData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = QuizData.json; sourceTree = "<group>"; };
 		0C5FC0862C7EB1D5009ABA64 /* EventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventManager.swift; sourceTree = "<group>"; };
+		0C5FC0882C7EDD06009ABA64 /* QuizData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = QuizData.json; sourceTree = "<group>"; };
+		0C5FC08C2C7EE08E009ABA64 /* AdminAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminAccount.swift; sourceTree = "<group>"; };
+		0C5FC08E2C7EE0E7009ABA64 /* Admin.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Admin.json; sourceTree = "<group>"; };
 		0C6396E72BAB4BB8008E046F /* RegisterNickname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNickname.swift; sourceTree = "<group>"; };
 		0C691EB02BBD9FF2004021F1 /* TimerGameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerGameViewModel.swift; sourceTree = "<group>"; };
 		0C691EB22BBDA028004021F1 /* TimerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerState.swift; sourceTree = "<group>"; };
@@ -344,10 +348,11 @@
 		0C3F4E682C0C44AB00EE9DB6 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				0C5FC08E2C7EE0E7009ABA64 /* Admin.json */,
 				0C6F75D42C7CEA1B0075FAC3 /* English */,
 				0C6F75D32C7CEA120075FAC3 /* Chinese */,
 				C98BDC3C2C75C60000ACBB46 /* LandmarkDescription.json */,
-				0C5FC0842C7EB1C8009ABA64 /* QuizData.json */,
+				0C5FC0882C7EDD06009ABA64 /* QuizData.json */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -419,6 +424,7 @@
 				C9519D3A2BB335EC00F69974 /* View+.swift */,
 				0C7C4E3B2C0777B600ABB4D8 /* Date+.swift */,
 				B9955B102C19C3360082FC60 /* Formatter+.swift */,
+				0C5FC08C2C7EE08E009ABA64 /* AdminAccount.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -946,6 +952,7 @@
 				C98078BD2BA872A300C04B2D /* blackDuckkuClicked.mp3 in Resources */,
 				C98078A12BA8715900C04B2D /* quizCorrect.mp3 in Resources */,
 				0C6F75D62C7CEA280075FAC3 /* LandmarkDescriptionEnglish.json in Resources */,
+				0C5FC08F2C7EE0EB009ABA64 /* Admin.json in Resources */,
 				0C5979B82BAB25EE00E8156D /* serviceKorean.txt in Resources */,
 				C98078A92BA871A000C04B2D /* cardClicked.mp3 in Resources */,
 				C980789C2BA8712700C04B2D /* cupidBad.mp3 in Resources */,
@@ -983,7 +990,7 @@
 				C980789D2BA8712700C04B2D /* cupidGoodOrPerfect.mp3 in Resources */,
 				C9F694EC2BA3251B009A8762 /* Assets.xcassets in Resources */,
 				C953D2F62BA47B0700318869 /* NeoDunggeunmoPro-Regular.ttf in Resources */,
-				0C5FC0852C7EB1C8009ABA64 /* QuizData.json in Resources */,
+				0C5FC0892C7EDD06009ABA64 /* QuizData.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1005,6 +1012,7 @@
 				B9105A012BDBFF8700D6455F /* AllClickGameViewModel.swift in Sources */,
 				C95F8F352BBAE1DA00E89B50 /* QuizGameView.swift in Sources */,
 				C9FE257B2BB3DFAA00F78C63 /* CheckLogoutView.swift in Sources */,
+				0C5FC08D2C7EE092009ABA64 /* AdminAccount.swift in Sources */,
 				0CEB87C72BB7E2B000CC2E4B /* CountdownView.swift in Sources */,
 				C9564D7F2BB9ADE600A869ED /* MoonGameView.swift in Sources */,
 				0CB902242BB6E77200F76311 /* TimerGameView.swift in Sources */,

--- a/playkuround-iOS/Extensions/AdminAccount.swift
+++ b/playkuround-iOS/Extensions/AdminAccount.swift
@@ -1,0 +1,15 @@
+//
+//  Account.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 8/28/24.
+//
+
+import SwiftUI
+
+struct AdminAccount: Codable {
+    let email: String
+    let password: String
+}
+
+let adminAccountInfo: [AdminAccount] = load("Admin.json")

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -72,6 +72,75 @@
     "enter token value:" : {
       "shouldTranslate" : false
     },
+    "Game.Admin.AdventureInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adventure the nearest Landmark"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가까운 랜드마크 탐험"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "探索您附近的建筑"
+          }
+        }
+      }
+    },
+    "Game.Admin.GameInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Game Play (no score)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "게임 플레이 (점수 반영 X)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游戏玩法（不计分）"
+          }
+        }
+      }
+    },
+    "Game.Admin.UploadInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playing the game directly so your score will be not uploaded."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "게임을 직접 플레이하여 점수가 반영되지 않습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自己玩游戏，所以你的分数不算数"
+          }
+        }
+      }
+    },
     "Game.AllClick.ClassRegistration" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -444,7 +444,7 @@ class GameViewModel: ObservableObject {
     
     // 사용자의 모험 점수(총점) 가져오는 함수
     func fetchAdventureScore() {
-        APIManager.callGETAPI(endpoint: .scoresRank) { result in
+        APIManager.shared.callGETAPI(endpoint: .scoresRank) { result in
             switch result {
             case .success(let data):
                 DispatchQueue.main.async {

--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -350,7 +350,7 @@ class GameViewModel: ObservableObject {
         if let landmarkID = mapViewModel.userLandmarkID {
             // Adventure API 호출
             // 전송 실패하더라도 callPOSTAPI 함수 내부에서 재전송 처리
-            APIManager.callPOSTAPI(endpoint: .adventures,
+            APIManager.shared.callPOSTAPI(endpoint: .adventures,
                                    parameters: ["landmarkId": landmarkID,
                                                 "latitude": latitude,
                                                 "longitude": longitude,
@@ -393,7 +393,7 @@ class GameViewModel: ObservableObject {
     
     // 사용자의 게임 최고 점수 가져오는 함수
     func fetchBestScore() {
-        APIManager.callGETAPI(endpoint: .gameScore) { result in
+        APIManager.shared.callGETAPI(endpoint: .gameScore) { result in
             switch result {
             case .success(let data):
                 if let apiResponse = data as? APIResponse {
@@ -480,10 +480,18 @@ class GameViewModel: ObservableObject {
     }
     
     private func handleError() {
-        DispatchQueue.main.async {
-            self.rootViewModel.transition(to: .home)
-            self.rootViewModel.openToastMessageView(message: NSLocalizedString("Network.UploadError", comment: ""))
-            // self.rootViewModel.openNewBadgeView(badgeNames: [])
+        let isAdmin = UserDefaults.standard.bool(forKey: "IS_ADMIN")
+        if isAdmin {
+            DispatchQueue.main.async {
+                self.rootViewModel.transition(to: .home)
+                self.rootViewModel.openToastMessageView(message: NSLocalizedString("Game.Admin.UploadInfo", comment: ""))
+            }
+        } else {
+            DispatchQueue.main.async {
+                self.rootViewModel.transition(to: .home)
+                self.rootViewModel.openToastMessageView(message: NSLocalizedString("Network.UploadError", comment: ""))
+                // self.rootViewModel.openNewBadgeView(badgeNames: [])
+            }
         }
     }
 }

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -82,7 +82,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - User Profile Data
     // 유저 프로필 데이터 불러오는 함수
     func loadUserData() {
-        APIManager.callGETAPI(endpoint: .users) { result in
+        APIManager.shared.callGETAPI(endpoint: .users) { result in
             switch result {
             case .success(let data):
                 print("Data received in View: \(data)")
@@ -105,7 +105,7 @@ final class HomeViewModel: ObservableObject {
             }
         }
         
-        APIManager.callGETAPI(endpoint: .scoresRank) { result in
+        APIManager.shared.callGETAPI(endpoint: .scoresRank) { result in
             switch result {
             case .success(let data):
                 print("Data received in View: \(data)")
@@ -143,7 +143,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - Badge List
     // 유저 뱃지 목록 불러오는 함수
     func loadBadge() {
-        APIManager.callGETAPI(endpoint: .badges) { result in
+        APIManager.shared.callGETAPI(endpoint: .badges) { result in
             switch result {
             case .success(let data):
                 print("Data received in View: \(data)")
@@ -165,7 +165,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - Attendance
     // 유저 출석 불러오는 함수
     func loadAttendance() {
-        APIManager.callGETAPI(endpoint: .attendances) { result in
+        APIManager.shared.callGETAPI(endpoint: .attendances) { result in
             switch result {
             case .success(let data):
                 print("Attendance GET: \(data)")
@@ -201,7 +201,7 @@ final class HomeViewModel: ObservableObject {
     }
     
     func attendance(latitude: Double, longitude: Double) {
-        APIManager.callPOSTAPI(endpoint: .attendances, parameters: ["latitude": latitude, "longitude": longitude]) { result in
+        APIManager.shared.callPOSTAPI(endpoint: .attendances, parameters: ["latitude": latitude, "longitude": longitude]) { result in
             switch result {
             case .success(let data):
                 // 출석 성공 이벤트
@@ -240,7 +240,7 @@ final class HomeViewModel: ObservableObject {
     
     // MARK: - Total Ranking
     func loadTotalRanking() {
-        APIManager.callGETAPI(endpoint: .scoresRank) { result in
+        APIManager.shared.callGETAPI(endpoint: .scoresRank) { result in
             switch result {
             case .success(let data):
                 print("loadTotalRanking(): \(data)")
@@ -268,7 +268,7 @@ final class HomeViewModel: ObservableObject {
     
     // MARK: - Landmark Ranking
     func loadLandmarkRanking(landmarkID: Int) {
-        APIManager.callGETAPI(endpoint: .scoresRankLandmark, landmarkID: landmarkID) { result in
+        APIManager.shared.callGETAPI(endpoint: .scoresRankLandmark, landmarkID: landmarkID) { result in
             switch result {
             case .success(let data):
                 print("loadLandmarkRanking(): \(data)")
@@ -297,7 +297,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - User Notification
     func loadUserNotification() {
         // TODO: 백엔드와 협의하여 version checking 도입 여부 결정 필요
-        APIManager.callGETAPI(endpoint: .notification, querys: ["version": "2.0.4", "os": "ios"]) { result in
+        APIManager.shared.callGETAPI(endpoint: .notification, querys: ["version": "2.0.4", "os": "ios"]) { result in
             switch result {
             case .success(let data as NotificationAPIResponse):
                 // 유저 알림 처리
@@ -354,7 +354,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - Adventure
     func adventure(latitude: Double, longitude: Double, mapViewModel: MapViewModel) {
         print("latitude: \(latitude), longitude: \(longitude)")
-        APIManager.callGETAPI(endpoint: .landmarks, querys: ["latitude": latitude, "longitude": longitude]) { result in
+        APIManager.shared.callGETAPI(endpoint: .landmarks, querys: ["latitude": latitude, "longitude": longitude]) { result in
             switch result {
             case .success(let data):
                 print("Nearest Landmark: \(data)")
@@ -476,7 +476,7 @@ final class HomeViewModel: ObservableObject {
     
     // 공지 받아오기
     func loadEvents() {
-        APIManager.callGETAPI(endpoint: .events) { result in
+        APIManager.shared.callGETAPI(endpoint: .events) { result in
             switch result {
             case .success(let data):
                 if let apiResponse = data as? EventAPIResponse {

--- a/playkuround-iOS/ViewModels/MapViewModel.swift
+++ b/playkuround-iOS/ViewModels/MapViewModel.swift
@@ -114,7 +114,7 @@ final class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate 
     
     // 사용자 랜드마크 업데이트
     func updateLandmark() {
-        APIManager.callGETAPI(endpoint: .landmarks,
+        APIManager.shared.callGETAPI(endpoint: .landmarks,
                               querys: ["latitude": userLatitude,
                                        "longitude": userLongitude]) { result in
             switch result {

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -185,6 +185,7 @@ final class RootViewModel: ObservableObject {
                 print("Data received in View: \(data)")
                 // 토큰 삭제
                 TokenManager.reset()
+                UserDefaults.standard.removeObject(forKey: "IS_ADMIN")
                 // 메인 뷰로 전환
                 self.transition(to: .main)
                 self.openToastMessageView(message: NSLocalizedString("MyPage.Logout.Done", comment: ""))

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -128,7 +128,7 @@ final class RootViewModel: ObservableObject {
         
         // 모든 스토리를 다 봤을 때 오리의 꿈 api 호출
         if stories.allSatisfy({ !$0.isLocked }) {
-            APIManager.callPOSTAPI(endpoint: .dreamOfDuck) { result in
+            APIManager.shared.callPOSTAPI(endpoint: .dreamOfDuck) { result in
                 switch result {
                 case .success(let data as BoolResponse):
                     print("Data received in View: \(data)")
@@ -179,7 +179,7 @@ final class RootViewModel: ObservableObject {
     // 로그아웃
     func logout() {
         // Logout API 요청
-        APIManager.callPOSTAPI(endpoint: .logout) { result in
+        APIManager.shared.callPOSTAPI(endpoint: .logout) { result in
             switch result {
             case .success(let data):
                 print("Data received in View: \(data)")

--- a/playkuround-iOS/Views/Home/Badge/ProfileBadgeView.swift
+++ b/playkuround-iOS/Views/Home/Badge/ProfileBadgeView.swift
@@ -80,7 +80,7 @@ struct ProfileBadgeView: View {
                         
                         Button {
                             if let selectedBadge = selectedBadge {
-                                APIManager.callPOSTAPI(endpoint: .profileBadge, parameters: ["profileBadge": selectedBadge.rawValue]) { result in
+                                APIManager.shared.callPOSTAPI(endpoint: .profileBadge, parameters: ["profileBadge": selectedBadge.rawValue]) { result in
                                     switch result {
                                     case .success(let data):
                                         print("(success) /api/users/profile-badge: \(data)")

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -150,69 +150,71 @@ struct HomeView: View {
                     
                     Spacer()
                     
-                    // 임시 구현
-                    /* Menu {
-                        Section("탐험") {
-                            Button("AdventureView 열기") {
-                                let latitude = mapViewModel.userLatitude
-                                let longitude = mapViewModel.userLongitude
-                                
-                                homeViewModel.adventure(latitude: latitude, longitude: longitude, mapViewModel: mapViewModel)
+                    // 어드민용
+                    if UserDefaults.standard.bool(forKey: "IS_ADMIN") {
+                        Menu {
+                            Section("Game.Admin.AdventureInfo") {
+                                Button("Home.Adventure") {
+                                    let latitude = mapViewModel.userLatitude
+                                    let longitude = mapViewModel.userLongitude
+                                    
+                                    homeViewModel.adventure(latitude: latitude, longitude: longitude, mapViewModel: mapViewModel)
+                                }
                             }
+                            
+                            Section("Game.Admin.GameInfo") {
+                                Button("Game.Card.Title") {
+                                    viewModel.transition(to: .cardGame)
+                                }
+                                Button("Game.Time.Title") {
+                                    viewModel.transition(to: .timeGame)
+                                }
+                                Button("Game.Moon.Title") {
+                                    viewModel.transition(to: .moonGame)
+                                }
+                                Button("Game.Quiz.Title") {
+                                    viewModel.transition(to: .quizGame)
+                                }
+                                Button("Game.Cupid.Title") {
+                                    viewModel.transition(to: .cupidGame)
+                                }
+                                Button("Game.AllClick.Title") {
+                                    viewModel.transition(to: .allClickGame)
+                                }
+                                Button("Game.Survive.Title") {
+                                    viewModel.transition(to: .surviveGame)
+                                }
+                                Button("Game.Catch") {
+                                    viewModel.transition(to: .catchGame)
+                                }
+                            }
+                        } label: {
+                            Image(.shortButtonBlue)
+                                .overlay {
+                                    Text("Home.Adventure")
+                                        .font(.neo18)
+                                        .foregroundColor(.kuText)
+                                        .kerning(-0.41)
+                                }
                         }
-                        
-                        Section("게임") {
-                            Button("책 뒤집기") {
-                                viewModel.transition(to: .cardGame)
-                            }
-                            Button("10초를 맞춰봐") {
-                                viewModel.transition(to: .timeGame)
-                            }
-                            Button("MOON을 점령해") {
-                                viewModel.transition(to: .moonGame)
-                            }
-                            Button("건쏠지식") {
-                                viewModel.transition(to: .quizGame)
-                            }
-                            Button("덕큐피트") {
-                                viewModel.transition(to: .cupidGame)
-                            }
-                            Button("Game.AllClick.Title") {
-                                viewModel.transition(to: .allClickGame)
-                            }
-                            Button("일감호에서 살아남기") {
-                                viewModel.transition(to: .surviveGame)
-                            }
-                            Button("덕쿠를 잡아라!") {
-                                viewModel.transition(to: .catchGame)
-                            }
+                        .padding(.bottom, shouldPadding ? 60 : 70)
+                    } else {
+                        Button {
+                            let latitude = mapViewModel.userLatitude
+                            let longitude = mapViewModel.userLongitude
+                            
+                            homeViewModel.adventure(latitude: latitude, longitude: longitude, mapViewModel: mapViewModel)
+                        } label: {
+                            Image(.shortButtonBlue)
+                                .overlay {
+                                    Text("Home.Adventure")
+                                        .font(.neo18)
+                                        .foregroundColor(.kuText)
+                                        .kerning(-0.41)
+                                }
                         }
-                    } label: {
-                        Image(.shortButtonBlue)
-                            .overlay {
-                                Text("Home.Adventure")
-                                    .font(.neo18)
-                                    .foregroundColor(.kuText)
-                                    .kerning(-0.41)
-                            }
+                        .padding(.bottom, shouldPadding ? 60 : 70)
                     }
-                    .padding(.bottom, shouldPadding ? 60 : 70) */
-                    
-                    Button {
-                        let latitude = mapViewModel.userLatitude
-                        let longitude = mapViewModel.userLongitude
-                        
-                        homeViewModel.adventure(latitude: latitude, longitude: longitude, mapViewModel: mapViewModel)
-                    } label: {
-                        Image(.shortButtonBlue)
-                            .overlay {
-                                Text("Home.Adventure")
-                                    .font(.neo18)
-                                    .foregroundColor(.kuText)
-                                    .kerning(-0.41)
-                            }
-                    }
-                    .padding(.bottom, shouldPadding ? 60 : 70)
                 }
                 .padding(.top, shouldPadding ? 12 : 9)
                 

--- a/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
+++ b/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
@@ -109,6 +109,7 @@ struct AuthenticationCodeView: View {
             }
         }
         
+        APIManager.shared.callGETAPI(endpoint: .emails,
                               querys: ["code" : code, "email" : email]) { result in
             switch result {
             case .success(let data):

--- a/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
+++ b/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
@@ -101,7 +101,14 @@ struct AuthenticationCodeView: View {
     }
     
     private func callGETAPIemails(code: String, email: String) {
-        APIManager.callGETAPI(endpoint: .emails,
+        // 심사용 계정 예외 처리
+        for account in adminAccountInfo {
+            if email == account.email && code == account.password {
+                APIManager.shared.changeServerType(to: .dev) // 개발 서버로 전환
+                UserDefaults.standard.setValue(true, forKey: "IS_ADMIN")
+            }
+        }
+        
                               querys: ["code" : code, "email" : email]) { result in
             switch result {
             case .success(let data):

--- a/playkuround-iOS/Views/Login/LoginView.swift
+++ b/playkuround-iOS/Views/Login/LoginView.swift
@@ -133,7 +133,7 @@ struct LoginView: View {
         // Save target email to UserDefaults
         UserDefaults.standard.set(target, forKey: "email")
         
-        APIManager.callPOSTAPI(endpoint: .emails,
+        APIManager.shared.callPOSTAPI(endpoint: .emails,
                                parameters: ["target" : target.lowercased()]) { result in
             switch result {
             case .success(let data):

--- a/playkuround-iOS/Views/Main/MainView.swift
+++ b/playkuround-iOS/Views/Main/MainView.swift
@@ -77,7 +77,7 @@ struct MainView: View {
     // 토큰 재발급 및 검사 함수
     private func reissueToken(token: String) {
         // reissue API 호출
-        APIManager.callPOSTAPI(endpoint: .reissue, parameters: ["refreshToken": token]) { result in
+        APIManager.shared.callPOSTAPI(endpoint: .reissue, parameters: ["refreshToken": token]) { result in
             switch result {
             case .success(let data):
                 // 재발급 완료된 경우 refresh token 만료 전이므로 자동 로그인

--- a/playkuround-iOS/Views/MyPage/MyPageListSectionView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageListSectionView.swift
@@ -175,7 +175,7 @@ struct MyPageListSectionView: View {
     }
     
     private func callPostAPIfakeDoor() {
-        APIManager.callPOSTAPI(endpoint: .fakeDoor) { result in }
+        APIManager.shared.callPOSTAPI(endpoint: .fakeDoor) { result in }
     }
     
     private func getTitle() -> String {

--- a/playkuround-iOS/Views/Register/RegisterNickname.swift
+++ b/playkuround-iOS/Views/Register/RegisterNickname.swift
@@ -150,7 +150,7 @@ struct RegisterNickname: View {
     
     // 서버 API 통해 닉네임이 사용 가능한지 검사
     private func checkNicknameAvailability() {
-        APIManager.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
+        APIManager.shared.callGETAPI(endpoint: .availability, querys: ["nickname": nickname]) { result in
             switch result {
             case .success(let data):
                 if let response = data as? BoolResponse {
@@ -198,7 +198,7 @@ struct RegisterNickname: View {
     }
     
     private func register(email: String, major: String, token: String) {
-        APIManager.callPOSTAPI(endpoint: .register, parameters: ["email": email, "nickname": nickname, "major": major, "authVerifyToken": token]) { result in
+        APIManager.shared.callPOSTAPI(endpoint: .register, parameters: ["email": email, "nickname": nickname, "major": major, "authVerifyToken": token]) { result in
             switch result {
             case .success(let data):
                 // TODO: Token 저장 및 Home으로 전환


### PR DESCRIPTION
### 🐣Issue
closed #202 
<br/>

### 🐣Motivation
심사용 계정 예외 처리 및 릴리즈 준비 작업을 했습니다
<br/>

### 🐣Key Changes
1. `AdminAccount` 구조체 추가
    - 어드민 계정에 대한 이메일과 코드를 저장합니다
    - `Admin.json`에서 읽어오며, 이 파일은 보안상 깃허브에 올리지 않습니다

2. 어드민 계정 예외 처리
    - 어드민 계정으로 로그인 시 서버를 개발 서버로 설정, 내부 "IS_ADMIN" 매개변수를 true로 설정
    - 홈 화면에서 탐험 버튼 누를 경우 기존에 디버깅용 UI를 활용
    - 어드민 계정으로 플레이 시 점수 업로드 X, 토스트 메시지 띄움 (게임을 직접 플레이하여 점수 반영되지 않습니다)

3. `APIManager` 수정
    - 기본 서버 배포 서버로 설정
    - 내부 서버 타입 변경 메서드 수정 (`APIManager.changeServerType(to: ServerType)`)
    - 어드민 로그인 시 배포 서버에서 개발 서버로 수정할 수 있도록
<br/>

### 🐣Simulation
| 어드민 계정 시 | 어드민 계정 게임 플레이 시 |
|--|--|
| <img width="300px" src="https://github.com/user-attachments/assets/6db73337-301b-4a7a-be8d-569444b74bc9"> | <img width="300px" src="https://github.com/user-attachments/assets/4e04c658-2913-4eb1-8ebb-5bf20fb25119"> |
<br/>

### 🐣To Reviewer
심사 올릴 준비 완료하였습니다. 실제 기기에서 구동 확인 했으며 로그인 잘 되고, 건대 밖에서 게임 플레이 잘 됩니다 (점수는 업로드 X)
확인해보시고 심사 올려주시면 감사드리겠습니다
<br/>

### 🐣Reference
X
<br/>
