### PR TITLE
[Fix] #205 - 심사용 계정 예외 처리 추가 구현

### DIFF
--- a/playkuround-iOS/ViewModels/GameViewModel.swift
+++ b/playkuround-iOS/ViewModels/GameViewModel.swift
@@ -326,10 +326,8 @@ class GameViewModel: ObservableObject {
             self.isCountdownViewPresented = false
             self.isPauseViewPresented = false
             
-            withAnimation(.spring) {
-                self.isResultViewPresented = true
-                print("after fetch \(self.isResultViewPresented)")
-            }
+            self.isResultViewPresented = true
+            print("after fetch \(self.isResultViewPresented)")
         }
     }
     
@@ -376,6 +374,8 @@ class GameViewModel: ObservableObject {
                         DispatchQueue.main.async {
                             self.rootViewModel.openNewBadgeView(badgeNames: newBadgeNameList, openNow: false)
                         }
+                    } else {
+                        self.handleError()
                     }
                     
                     self.fetchBestScore()
@@ -432,7 +432,11 @@ class GameViewModel: ObservableObject {
                         DispatchQueue.main.async {
                             self.rootViewModel.openNewBadgeView(badgeNames: newBadgeNameList, openNow: false)
                         }
+                    } else {
+                        self.handleError()
                     }
+                } else {
+                    self.handleError()
                 }
                 print("Best Score: \(self.bestScore)")
                 self.fetchAdventureScore()
@@ -451,6 +455,8 @@ class GameViewModel: ObservableObject {
                     if let response = data as? APIResponse {
                         if let myRank = response.response?.myRank {
                             self.adventureScore = myRank.score
+                        } else {
+                            self.handleError()
                         }
                         
                         // 뱃지 있으면 추가
@@ -466,6 +472,8 @@ class GameViewModel: ObservableObject {
                         DispatchQueue.main.async {
                             self.rootViewModel.openNewBadgeView(badgeNames: newBadgeNameList, openNow: false)
                         }
+                    } else {
+                        self.handleError()
                     }
                     print("Adventure Score: \(self.adventureScore)")
                     


### PR DESCRIPTION
### 🐣Issue
closed #205 
<br/>

### 🐣Motivation
심사용 어드민 계정 예외 처리를 추가했습니다
<br/>

### 🐣Key Changes
백엔드와 얘기하여 수정한 내용입니다
기존에는 메일 전송까지는 배포 서버로 하고, 인증 번호 입력 시에만 개발 서버로 변경하였는데, 실제 배포 서버에서 5회 제한이 걸리게 되어 메일 어드민 이메일에 대해서는 개발 서버로 메일 전송을 하도록 수정
추가로 어드민 계정은 5회 초과하여도 인증번호 입력창은 뜨도록 수정
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
