### PR TITLE
[Feat] #207 - 계정 삭제 기능 구현

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C048FDE2C7F8FBB000DD175 /* CheckDeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C048FDD2C7F8FBB000DD175 /* CheckDeleteAccountView.swift */; };
 		0C0CDA2C2C2955B0003D12BA /* LandmarkRankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0CDA2B2C2955B0003D12BA /* LandmarkRankingView.swift */; };
 		0C0CDA312C299021003D12BA /* AdventureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0CDA302C299021003D12BA /* AdventureView.swift */; };
 		0C27DDF02BBD714F0049B7B8 /* CardComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27DDEF2BBD714F0049B7B8 /* CardComponent.swift */; };
@@ -160,6 +161,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0C048FDD2C7F8FBB000DD175 /* CheckDeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDeleteAccountView.swift; sourceTree = "<group>"; };
 		0C0CDA2B2C2955B0003D12BA /* LandmarkRankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkRankingView.swift; sourceTree = "<group>"; };
 		0C0CDA302C299021003D12BA /* AdventureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventureView.swift; sourceTree = "<group>"; };
 		0C27DDEF2BBD714F0049B7B8 /* CardComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponent.swift; sourceTree = "<group>"; };
@@ -734,6 +736,7 @@
 				C97543F32BB3244800CD6479 /* MyPageListSectionView.swift */,
 				C97543F52BB325A300CD6479 /* MyPageListRowView.swift */,
 				C9FE257A2BB3DFAA00F78C63 /* CheckLogoutView.swift */,
+				0C048FDD2C7F8FBB000DD175 /* CheckDeleteAccountView.swift */,
 				C9FE257C2BB40E1C00F78C63 /* CheerPKTeamView.swift */,
 			);
 			path = MyPage;
@@ -1037,6 +1040,7 @@
 				0C9641EA2BB92D6300838DA9 /* GameResultView.swift in Sources */,
 				0CA82DB22C70B93400914DC4 /* ProfileBadgeView.swift in Sources */,
 				C953D3042BA49BB300318869 /* MainView.swift in Sources */,
+				0C048FDE2C7F8FBB000DD175 /* CheckDeleteAccountView.swift in Sources */,
 				C918F4052BA7149A00C0BFDA /* SoundManager.swift in Sources */,
 				0CA07D6F2BFDA96F00564AEB /* SurviveGameView.swift in Sources */,
 				0C7C4E3C2C0777B600ABB4D8 /* Date+.swift in Sources */,

--- a/playkuround-iOS/Extensions/Managers/APIManager.swift
+++ b/playkuround-iOS/Extensions/Managers/APIManager.swift
@@ -116,6 +116,7 @@ final class APIManager {
     private func fetchDataGET(from endpoint: GETAPICollections,
                                      querys: [String: Any]? = nil,
                                      landmarkID: Int? = nil,
+                                     delete: Bool,
                                      completion: @escaping (Result<Any, Error>) -> Void) {
         // URL과 쿼리 파라미터를 포함하여 URLRequest 생성
         var urlComponents: URLComponents
@@ -167,7 +168,13 @@ final class APIManager {
         }
 
         // HTTP 메소드 설정
-        request.httpMethod = "GET"
+        // 회원 삭제 예외 처리
+        if endpoint == .users && delete {
+            request.httpMethod = "DELETE"
+            print("httpMethod is set to DELETE")
+        } else {
+            request.httpMethod = "GET"
+        }
 
         // 네트워크 요청 수행
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
@@ -374,6 +381,7 @@ extension APIManager {
                            querys: [String: Any]? = nil,
                            depth: Int = 0,
                            landmarkID: Int? = nil,
+                           delete: Bool = false,
                            completion: @escaping (Result<Any, Error>) -> Void) {
         // max depth reached return with error
         if depth >= 2 {
@@ -395,6 +403,7 @@ extension APIManager {
         fetchDataGET(from: endpoint, 
                      querys: querys,
                      landmarkID: landmarkID,
+                     delete: delete,
                      completion: { result in
             switch result {
             case .success(let data):

--- a/playkuround-iOS/Extensions/Managers/GAManager.swift
+++ b/playkuround-iOS/Extensions/Managers/GAManager.swift
@@ -81,6 +81,7 @@ final class GAManager {
         case LOGOUT // 로그아웃
         case OPEN_INSTAGRAM // 인스타그램 바로가기
         case CHEERING // 응원하기
+        case DELETE_ACCOUNT // 회원 탈퇴
         
         case CHANGE_LANGUAGE // 언어 변경 (설정 열기)
         

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -2358,6 +2358,29 @@
         }
       }
     },
+    "MyPage.DeleteAccount.AfterMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your account has been deleted. Thank you for using PLAYKUROUND."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정이 삭제되었습니다. 플레이쿠라운드를 이용해주셔서 감사합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您的帐户已被删除。感谢您使用 PLAYKUROUND。"
+          }
+        }
+      }
+    },
     "MyPage.DeleteAccount.Message" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -2335,6 +2335,52 @@
         }
       }
     },
+    "MyPage.DeleteAccount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Account"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 삭제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除账户"
+          }
+        }
+      }
+    },
+    "MyPage.DeleteAccount.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure to delete account?<br>All data will be deleted"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정을 삭제하시겠습니까?<br>모든 데이터가 삭제됩니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要删除帐户?<br>所有数据将被删除"
+          }
+        }
+      }
+    },
     "MyPage.FeedbackURL" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -191,7 +191,27 @@ final class RootViewModel: ObservableObject {
                 self.openToastMessageView(message: NSLocalizedString("MyPage.Logout.Done", comment: ""))
             case .failure(let error):
                 print("로그아웃 실패")
-                print("Error in View: \(error)")
+                self.openToastMessageView(message:
+                                            NSLocalizedString("Network.ServerError", comment: ""))
+            }
+        }
+    }
+    
+    // 회원 탈퇴
+    func deleteAccount() {
+        APIManager.shared.callGETAPI(endpoint: .users, delete: true) { result in
+            switch result {
+            case .success(let data):
+                TokenManager.reset()
+                UserDefaults.standard.removeObject(forKey: "IS_ADMIN")
+                // 메인 뷰로 전환
+                self.transition(to: .main)
+                let message = NSLocalizedString("MyPage.DeleteAccount.AfterMessage", comment: "")
+                self.openToastMessageView(message: message)
+            case .failure(let error):
+                print("계정 삭제 실패")
+                self.openToastMessageView(message:
+                                            NSLocalizedString("Network.ServerError", comment: ""))
             }
         }
     }

--- a/playkuround-iOS/Views/MyPage/CheckDeleteAccountView.swift
+++ b/playkuround-iOS/Views/MyPage/CheckDeleteAccountView.swift
@@ -1,0 +1,65 @@
+//
+//  CheckLogoutView.swift
+//  playkuround-iOS
+//
+//  Created by Seoyeon Choi on 3/27/24.
+//
+
+import SwiftUI
+
+struct CheckDeleteAccountView: View {
+    @ObservedObject var viewModel: RootViewModel
+    @Binding var isDeleteAccountPresented: Bool
+    
+    private let soundManager = SoundManager.shared
+    
+    var body: some View {
+        ZStack {
+            Color.black
+                .opacity(0.66)
+                .ignoresSafeArea(.all)
+                .onTapGesture {
+                    isDeleteAccountPresented = false
+                }
+            
+            VStack {
+                let message = NSLocalizedString("MyPage.DeleteAccount.Message", comment: "")
+                    .replacingOccurrences(of: "<br>", with: "\n")
+                
+                Text(message)
+                    .font(.neo20)
+                    .kerning(-0.41)
+                    .foregroundStyle(.white)
+                    .padding(.bottom, 15)
+                
+                Button(action: {
+                    isDeleteAccountPresented = false
+                    viewModel.deleteAccount()
+                    soundManager.playSound(sound: .buttonClicked)
+                }, label: {
+                    Image(.shortButtonBlue)
+                        .overlay {
+                            Text("MyPage.Logout.Ok")
+                                .font(.neo20)
+                                .kerning(-0.41)
+                                .foregroundStyle(.black)
+                        }
+                        .padding(.bottom, 7)
+                })
+                
+                Button(action: {
+                    isDeleteAccountPresented = false
+                    soundManager.playSound(sound: .buttonClicked)
+                }, label: {
+                    Image(.shortButtonGray)
+                        .overlay {
+                            Text("MyPage.Logout.No")
+                                .font(.neo20)
+                                .kerning(-0.41)
+                                .foregroundStyle(.black)
+                        }
+                })
+            }
+        }
+    }
+}

--- a/playkuround-iOS/Views/MyPage/MyPageListSectionView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageListSectionView.swift
@@ -44,6 +44,17 @@ struct MyPageListSectionView: View {
                         // 로그아웃 이벤트
                         GAManager.shared.logEvent(.LOGOUT)
                     }
+                
+                // 계정 삭제
+                MyPageListRowView(rowTitle: NSLocalizedString("MyPage.DeleteAccount", comment: ""))
+                    .onTapGesture {
+                        NotificationCenter.default.post(name: NSNotification.Name("isDeleteAccountPresented"),
+                                                        object: nil)
+                        soundManager.playSound(sound: .buttonClicked)
+                        
+                        // 로그아웃 이벤트
+                        GAManager.shared.logEvent(.DELETE_ACCOUNT)
+                    }
             }
             
             // 설정

--- a/playkuround-iOS/Views/MyPage/MyPageView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageView.swift
@@ -13,6 +13,7 @@ struct MyPageView: View {
     
     @State private var isStoryViewPresented: Bool = false
     @State private var isLogoutPresented: Bool = false
+    @State private var isDeleteAccountPresented: Bool = false
     @State private var isCheerPresented: Bool = false
     @State private var isServiceTermsViewPresented: Bool = false
     @State private var isPrivacyTermsViewPresented: Bool = false
@@ -77,6 +78,10 @@ struct MyPageView: View {
             else if isCheerPresented {
                 CheerPKTeamView()
             }
+            else if isDeleteAccountPresented {
+                CheckDeleteAccountView(viewModel: viewModel,
+                                       isDeleteAccountPresented: $isDeleteAccountPresented)
+            }
             
             Spacer()
                 .customNavigationBar(
@@ -108,6 +113,11 @@ struct MyPageView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("logoutViewPresented"))) { _ in
             withAnimation(.spring(duration: 0.5, bounce: 0.3)) {
                 self.isLogoutPresented = true
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("isDeleteAccountPresented"))) { _ in
+            withAnimation(.spring(duration: 0.5, bounce: 0.3)) {
+                self.isDeleteAccountPresented = true
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("cheerViewPresented"))) { _ in


### PR DESCRIPTION
### 🐣Issue
closed #207 
<br/>

### 🐣Motivation
계정 삭제 기능을 구현합니다
<br/>

### 🐣Key Changes
- 마이페이지에 My 섹션에 계정 삭제 세션 추가
- 기존 `CheckLogoutView` 디자인 활용하여 `CheckDeleteAccountView` 구현
- 다국어 적용
- `RootViewModel`에 회원탈퇴 함수 `rootViewModel.deleteAccount()` 구현
    - 서버 회원 탈퇴 API 요청
    - 토큰 삭제 
    - 메인으로 이동
```swift
// 회원 탈퇴
func deleteAccount() {
    APIManager.shared.callGETAPI(endpoint: .users, delete: true) { result in
        switch result {
        case .success(let data):
            TokenManager.reset()
            UserDefaults.standard.removeObject(forKey: "IS_ADMIN")
            // 메인 뷰로 전환
            self.transition(to: .main)
            let message = NSLocalizedString("MyPage.DeleteAccount.AfterMessage", comment: "")
            self.openToastMessageView(message: message)
        case .failure(let error):
            print("계정 삭제 실패")
            self.openToastMessageView(message:
                                        NSLocalizedString("Network.ServerError", comment: ""))
        }
    }
}
```
<br/>

### 🐣Simulation
| 마이페이지 | 계정 삭제 확인 뷰 |
|--|--|
| <img width="300px" src="https://github.com/user-attachments/assets/25f3b8bb-8efa-4ab7-b5b9-f0a17310b065"> | <img width="300px" src="https://github.com/user-attachments/assets/8a98cd7e-0284-4a87-87e5-6f416f1c2ba3"> |
<br/>

| 탈퇴 시연 영상 |
|--|
| <video width="300px" src="https://github.com/user-attachments/assets/182e12a9-2970-4a9d-b49a-661ca7d8a367"> |

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
