### PR TITLE
[Fix] #211 - QA 우선 디자인 수정사항 1차 반영

### DIFF
--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -2611,6 +2611,29 @@
         }
       }
     },
+    "MyPage.RankingUnit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "th"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "등"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名"
+          }
+        }
+      }
+    },
     "MyPage.Setting.CurrentLanguage" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -1200,7 +1200,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "뱃지 아이콘 선택"
+            "value" : "배지 아이콘 선택"
           }
         },
         "zh-Hans" : {

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -968,13 +968,36 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "건물설명"
+            "value" : "건물 설명"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "建筑说明"
+          }
+        }
+      }
+    },
+    "Home.Landmark.BuildingInfoTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building Information"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건물 정보"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建筑信息"
           }
         }
       }

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -1471,8 +1471,8 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Attendance check : 1 point <br>Complete 1 expedition : 5 points <br>Additional exploration (after all exploration is complete) : 1 point"
+            "state" : "translated",
+            "value" : "Game score aggregation + attendance score<br>Attendance score: 10 pts<br>Game Score: Personal best score until reset"
           }
         },
         "ko" : {
@@ -1483,8 +1483,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "签到:1分<br>探险 完成1个:5分<br>追加 探险（所有探险结束后）:1分"
+            "state" : "translated",
+            "value" : "游戏得分合计 + 出勤率得分<br> 出勤率得分: 10分 <br>游戏得分： 重置前个人最好成绩"
           }
         }
       }

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -1471,19 +1471,19 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Attendance check : 1 point <br>Complete 1 expedition : 5 points <br>Additional exploration (after all exploration is complete) : 1 point"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "출석 체크 : 1점<br>탐험 1개 완료 : 5점<br>추가 탐험(모든 탐험 완료 후) : 1점"
+            "value" : "게임 별 점수의 합계 집계 + 출석점수<br>출석 점수: 10점<br>게임 점수: 랭킹 초기화 전까지 개인 최고 점수"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "签到:1分<br>探险 完成1个:5分<br>追加 探险（所有探险结束后）:1分"
           }
         }

--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -3175,6 +3175,29 @@
     "POST" : {
       "shouldTranslate" : false
     },
+    "Ranking.ScoreTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pts"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "점"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分"
+          }
+        }
+      }
+    },
     "refresb" : {
       "shouldTranslate" : false
     },

--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -66,7 +66,11 @@ struct HomeView: View {
                                         .foregroundStyle(.white)
                                         .kerning(-0.41)
                                     Spacer()
-                                    Text("\(homeViewModel.userData.myRank.ranking)" + NSLocalizedString("Home.RankingUnit", comment: ""))
+                                    
+                                    let rank = homeViewModel.userData.myRank.ranking == 0 ?
+                                                "- " : "\(homeViewModel.userData.myRank.ranking)"
+                                    
+                                    Text(rank + NSLocalizedString("Home.RankingUnit", comment: ""))
                                         .font(.neo12)
                                         .foregroundStyle(.white)
                                         .kerning(-0.41)

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkDetailView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkDetailView.swift
@@ -72,20 +72,28 @@ struct LandmarkDetailView: View {
                                     .font(.pretendard15R)
                                     .foregroundStyle(.kuText)
                                     .multilineTextAlignment(.center)
+                                    .padding(.bottom, 20)
+                                
+                                Text("Home.Landmark.BuildingInfoTitle")
+                                    .font(.neo18)
+                                    .kerning(-0.41)
+                                    .foregroundStyle(.kuText)
+                                    .padding(.bottom, 8)
                                 
                                 let information = homeViewModel.landmarkDescriptions[landmarkIndex].information
                                 
-                                ForEach(Array(information.enumerated()), id: \.offset) { index, info in
-                                    Text(info.title)
-                                        .font(.neo18)
-                                        .kerning(-0.41)
-                                        .foregroundStyle(.kuText)
-                                        .padding(.top, 12)
-                                    
-                                    Text(info.content)
-                                        .font(.pretendard15R)
-                                        .foregroundStyle(.kuText)
-                                        .multilineTextAlignment(.center)
+                                VStack(alignment: .leading, spacing: 0) {
+                                    ForEach(Array(information.enumerated()), id: \.offset) { index, info in
+                                        Text(info.title)
+                                            .font(.pretendard15B)
+                                            .foregroundStyle(.kuText)
+                                        
+                                        Text(info.content)
+                                            .font(.pretendard15R)
+                                            .foregroundStyle(.kuText)
+                                            .multilineTextAlignment(.leading)
+                                            .padding(.bottom, 20)
+                                    }
                                 }
                             }
                             .padding(.vertical, 18)
@@ -110,6 +118,7 @@ struct LandmarkDetailView: View {
                 }
         }
         .onAppear {
+            homeViewModel.selectedLandmarkID = 1
             GAManager.shared.logScreenEvent(.LandmarkDetailView,
                                             landmarkID: homeViewModel.getSelectedLandmark().number)
         }

--- a/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
@@ -50,6 +50,8 @@ struct LandmarkRankingView: View {
                                                     .font(.neo20)
                                                     .foregroundColor(.kuText)
                                                     .kerning(-0.41)
+                                                    .minimumScaleFactor(0.5)
+                                                    .lineLimit(1)
                                             }
                                             .offset(y: 81)
                                     }

--- a/playkuround-iOS/Views/Home/Notification/NotificationView.swift
+++ b/playkuround-iOS/Views/Home/Notification/NotificationView.swift
@@ -78,7 +78,7 @@ struct NotificationView: View {
                                                     .scaledToFit()
                                                     .frame(width: 210)
                                             } placeholder: {
-                                                LoadingImage(loadingColor: .black)
+                                                LoadingImage(loadingColor: .white)
                                                     .frame(width: 210)
                                             }
                                             Spacer()
@@ -96,7 +96,7 @@ struct NotificationView: View {
                                                     .scaledToFit()
                                                     .frame(width: 210)
                                             } placeholder: {
-                                                LoadingImage(loadingColor: .black)
+                                                LoadingImage(loadingColor: .white)
                                                     .frame(width: 210)
                                             }
                                             Spacer()

--- a/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
+++ b/playkuround-iOS/Views/Home/TotalRanking/TotalRankingView.swift
@@ -64,10 +64,12 @@ struct TotalRankingView: View {
                                                             .frame(width: 60, height: 23)
                                                             .foregroundStyle(.kuBrown)
                                                             .overlay {
-                                                                Text("\(rank2.score.decimalFormatter)" + NSLocalizedString("Home.RankingUnit2", comment: ""))
+                                                                Text("\(rank2.score.decimalFormatter)" + NSLocalizedString("Ranking.ScoreTitle", comment: ""))
                                                                     .font(.neo18)
                                                                     .kerning(-0.41)
                                                                     .foregroundStyle(.white)
+                                                                    .minimumScaleFactor(0.5)
+                                                                    .lineLimit(1)
                                                             }
                                                             .padding(.bottom, 128)
                                                     }
@@ -103,10 +105,12 @@ struct TotalRankingView: View {
                                                         .frame(width: 60, height: 23)
                                                         .foregroundStyle(.kuBrown)
                                                         .overlay {
-                                                            Text("\(rank1.score.decimalFormatter)" + NSLocalizedString("Home.RankingUnit1", comment: ""))
+                                                            Text("\(rank1.score.decimalFormatter)" + NSLocalizedString("Ranking.ScoreTitle", comment: ""))
                                                                 .font(.neo18)
                                                                 .kerning(-0.41)
                                                                 .foregroundStyle(.white)
+                                                                .minimumScaleFactor(0.5)
+                                                                .lineLimit(1)
                                                         }
                                                         .padding(.bottom, 128)
                                                 }
@@ -142,10 +146,12 @@ struct TotalRankingView: View {
                                                             .frame(width: 60, height: 23)
                                                             .foregroundStyle(.kuBrown)
                                                             .overlay {
-                                                                Text("\(rank3.score.decimalFormatter)" + NSLocalizedString("Home.RankingUnit3", comment: ""))
+                                                                Text("\(rank3.score.decimalFormatter)" + NSLocalizedString("Ranking.ScoreTitle", comment: ""))
                                                                     .font(.neo18)
                                                                     .kerning(-0.41)
                                                                     .foregroundStyle(.white)
+                                                                    .minimumScaleFactor(0.5)
+                                                                    .lineLimit(1)
                                                             }
                                                             .padding(.bottom, 128)
                                                     }

--- a/playkuround-iOS/Views/MyPage/MyPageProfileView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageProfileView.swift
@@ -29,8 +29,10 @@ struct MyPageProfileView: View {
                 .font(.pretendard15R)
                 .foregroundStyle(.kuText)
                 .padding(.trailing, 15)
+            
+            let userRank = "(" + (user.myRank.ranking == 0 ? "- " : "\(user.myRank.ranking)")
 
-            let currentScoreValue = Text("\(String(describing: user.myRank.score))" + NSLocalizedString("Home.ScoreTitle", comment: "") + " (\(user.myRank.ranking == 0 ? "-" : "\(user.myRank.ranking)")" + NSLocalizedString("Home.RankingUnit", comment: "") + ")")
+            let currentScoreValue = Text("\(String(describing: user.myRank.score))" + NSLocalizedString("Home.ScoreTitle", comment: "") + userRank + NSLocalizedString("MyPage.RankingUnit", comment: "") + ")")
                 .font(.neo20)
                 .kerning(-0.41)
                 .foregroundStyle(.kuText)
@@ -49,8 +51,10 @@ struct MyPageProfileView: View {
                 .font(.pretendard15R)
                 .foregroundStyle(.kuText)
                 .padding(.trailing, 15)
+            
+            let highestRank = "(" + (user.highestRank == "-" ? "- " : "\(user.highestRank)")
 
-            let highestScoreValue = Text("\(String(describing: user.highestScore))" + NSLocalizedString("Home.ScoreTitle", comment: "") + " (\(user.highestRank)" + NSLocalizedString("Home.RankingUnit", comment: "") + ")")
+            let highestScoreValue = Text("\(String(describing: user.highestScore))" + NSLocalizedString("Home.ScoreTitle", comment: "") + highestRank + NSLocalizedString("MyPage.RankingUnit", comment: "") + ")")
                 .font(.neo20)
                 .kerning(-0.41)
                 .foregroundStyle(.kuText)


### PR DESCRIPTION
### 🐣Issue
closed #211 
<br/>

### 🐣Motivation
QA 우선 디자인 수정사항 1차 반영합니다
<br/>

### 🐣Key Changes
1. 랜드마크 건물 설명 수정
    - 제목 볼드 처리 및 좌측 정렬 → 완료
2. 마이페이지 랭킹 0위면 - 표시, "위" → "등" 수정 → 완료
3. 랭킹 기준, 랭킹 점수 생략 처리 텍스트 수정 (3~4자리 넘어가면 100..과같이 보임)
4. "뱃지" → "배지"
5. 로딩 다이얼로그 흰색으로 통일
6. 랭킹 기준 설명 수정
<br/>

### 🐣Simulation
**랜드마크 건물설명**
| 수정 |
|--|
| <img width="280px" src="https://github.com/user-attachments/assets/840a29e2-2ba0-4b53-9f91-17b2565471ad"> |
<br>

**등수 표시 수정**
| 마이페이지 | 홈 |
|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/08a15c18-15ce-4add-afef-8fa5ad56e4f5"> | <img width="280px" src="https://github.com/user-attachments/assets/be8fdbb5-9a26-4652-885b-d1e9fad7cb4f"> |
<br>

**랭킹 3~4자리 넘어가면 ...으로 잘림**
| 수정 |
|--|
| <img width="800px" src="https://github.com/user-attachments/assets/786fcffd-7f4b-46e3-befc-e0f5a236f4c7"> | 
<br>

**프로필 뱃지 선택창**
| 수정 |
|--|
| <img width="300px" src="https://github.com/user-attachments/assets/b6d36a06-b44d-4e5f-8674-2ff1dc616f0c"> |
<br>

**랭킹 기준 설명  멘트 수정**
| 랭킹 기준 | 
|--|
| <img width="300px" src="https://github.com/user-attachments/assets/28278b2e-e2dd-4fa7-97c0-8c702c292ef9"> |
<br>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
