### PR TITLE
[Fix] #230 - UserEntity 객체 Attribute 오류 수정

### DIFF
--- a/playkuround-iOS/Extensions/Managers/APIManager.swift
+++ b/playkuround-iOS/Extensions/Managers/APIManager.swift
@@ -844,7 +844,7 @@ struct Response: Codable {
     let email: String?
     let major: String?
     let highestScore: Int?
-    let highestRank: String?
+    let highestRank: Int?
     let attendanceDays: Int?
     let profileBadge: String?
     

--- a/playkuround-iOS/Models/UserEntity.swift
+++ b/playkuround-iOS/Models/UserEntity.swift
@@ -13,7 +13,7 @@ struct UserEntity {
     var myRank: MyRank // 전체 랭킹
     var landmarkRank: MyRank // 랜드마크별 랭킹
     var highestScore: Int
-    var highestRank: String
+    var highestRank: Int
     var attendanceDays: Int
     var profileBadge: String
 }

--- a/playkuround-iOS/ViewModels/HomeViewModel.swift
+++ b/playkuround-iOS/ViewModels/HomeViewModel.swift
@@ -16,7 +16,7 @@ final class HomeViewModel: ObservableObject {
     @Published var userData: UserEntity = UserEntity(nickname: "", major: "",
                                                      myRank: MyRank(score: 0, ranking: 0, profileBadge: "NONE"),
                                                      landmarkRank: MyRank(score: 0, ranking: 0, profileBadge: "NONE"),
-                                                     highestScore: 0, highestRank: "", attendanceDays: 0, profileBadge: "NONE")
+                                                     highestScore: 0, highestRank: 0, attendanceDays: 0, profileBadge: "NONE")
     @Published var badgeList: [BadgeResponse] = []
     @Published var attendanceList: [String] = []
     
@@ -93,7 +93,7 @@ final class HomeViewModel: ObservableObject {
                             self.userData.nickname = response.response?.nickname ?? "-"
                             self.userData.major = response.response?.major ?? "-"
                             self.userData.highestScore = response.response?.highestScore ?? 0
-                            self.userData.highestRank = response.response?.highestRank ?? "-"
+                            self.userData.highestRank = response.response?.highestRank ?? 0
                             self.userData.attendanceDays = response.response?.attendanceDays ?? 0
                             self.userData.profileBadge = response.response?.profileBadge ?? "NONE"
                         }

--- a/playkuround-iOS/Views/MyPage/MyPageProfileView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageProfileView.swift
@@ -52,7 +52,7 @@ struct MyPageProfileView: View {
                 .foregroundStyle(.kuText)
                 .padding(.trailing, 15)
             
-            let highestRank = "(" + (user.highestRank == "-" ? "- " : "\(user.highestRank)")
+            let highestRank = "(" + (user.highestRank == 0 ? "- " : "\(user.highestRank)")
 
             let highestScoreValue = Text("\(String(describing: user.highestScore))" + NSLocalizedString("Home.ScoreTitle", comment: "") + highestRank + NSLocalizedString("MyPage.RankingUnit", comment: "") + ")")
                 .font(.neo20)


### PR DESCRIPTION
### 🐣Issue
closed #230 
<br/>

### 🐣Motivation
UserEntity 객체 Attribute 오류 수정했습니다
<br/>

### 🐣Key Changes
기존에 UserEntity 내 HighestRank Attribute가 String으로 되어있어 이를 Int로 수정했습니다.
개발 서버에서는 항상 응답이 nil이라 몰랐는데 실서버로 가니 오류가 생기더군요
관련 코드 (마이페이지, APIManager, HomeViewModel) 수정했습니다
<br/>

```swift
struct UserEntity {
    var nickname: String
    var major: String
    var myRank: MyRank // 전체 랭킹
    var landmarkRank: MyRank // 랜드마크별 랭킹
    var highestScore: Int
    var highestRank: Int // String → Int
    var attendanceDays: Int
    var profileBadge: String
}
```
<br/>

### 🐣Simulation
| 실서버 홈 | 실서버 마이페이지 |
|--|--|
| <img width="300px" src="https://github.com/user-attachments/assets/efbf61f4-c0e4-4b12-b59a-096410a18533"> | <img width="300px" src="https://github.com/user-attachments/assets/072dab2e-b619-4bd9-8bad-bb102250a371"> |
<br/>

### 🐣To Reviewer
실서버에서 잘 작동함 테스트 완료
<br/>

### 🐣Reference
X
<br/>
