### PR TITLE
[Fix] #223 - 수강신청 ALL 클릭 QA 반영

### DIFF
--- a/playkuround-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/playkuround-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e17d61f26df0f0e06f58f6977ba05a097a720106",
-        "version" : "1.27.1"
+        "revision" : "edb6ed4919f7756157fe02f2552b7e3850a538e5",
+        "version" : "1.28.1"
       }
     }
   ],

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickCustomTextView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickCustomTextView.swift
@@ -87,6 +87,7 @@ struct AllClickCustomTextView: UIViewRepresentable {
         }
         
         func clearText() {
+            self.parent.text = ""
             textView?.text = ""
         }
         

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
@@ -77,12 +77,22 @@ struct AllClickGameView: View {
                         
                         Image(.allClickWritingBox)
                             .overlay(alignment: .leading) {
-                                AllClickCustomTextView(text: $userText,
+                                AllClickCustomTextView(viewModel: viewModel,
+                                                       text: $userText,
                                                        height: $userHeight,
                                                        shouldBecomeFirstResponder: $shouldBecomeFirstResponder)
                                 .frame(height: 30, alignment: .center)
                                 .frame(width: 200)
                                 .padding(.leading, 8)
+                                .overlay(alignment: .leading) {
+                                    if userText.isEmpty {
+                                        Text("Game.AllClick.WriteSubject")
+                                            .font(.neo18)
+                                            .kerning(-0.41)
+                                            .foregroundStyle(.kuGray2)
+                                            .padding(.leading, 16)
+                                    }
+                                }
                             }
                         
                         Spacer()
@@ -147,16 +157,6 @@ struct AllClickGameView: View {
             .onChange(of: viewModel.countdownCompleted) { completed in
                 if completed {
                     shouldBecomeFirstResponder = true
-                }
-            }
-            .onChange(of: userText) { newText in
-                if let index = viewModel.subjects.firstIndex(where: { $0.title == newText }) {
-                    viewModel.calculateScore(index: index)
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        viewModel.subjects.remove(at: index)
-                        viewModel.soundManager.playSound(sound: .classCorrect)
-                        userText = ""
-                    }
                 }
             }
             .onChange(of: scenePhase) { newPhase in

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
@@ -65,7 +65,6 @@ struct AllClickGameView: View {
                                     Spacer()
                                 }
                             }
-                            .background(.yellow)
                             .overlay {
                                 ForEach(viewModel.subjects.indices, id: \.self) { index in
                                     AllClickTextRainView(subject: viewModel.subjects[index])

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
@@ -63,6 +63,9 @@ struct AllClickGameView: View {
                                           y: viewModel.subjects[index].yPosition)
                         }
                     }
+                    .onAppear {
+                        viewModel.setFrameXY(x: geometry.size.width, y: geometry.size.height)
+                    }
                     .padding(.top, 10)
                     
                     HStack(spacing: 0) {

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
@@ -97,7 +97,7 @@ struct AllClickGameView: View {
                                 .frame(width: 200)
                                 .padding(.leading, 8)
                                 .overlay(alignment: .leading) {
-                                    if userText.isEmpty {
+                                    if userText == "" {
                                         Text("Game.AllClick.WriteSubject")
                                             .font(.neo18)
                                             .kerning(-0.41)

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
@@ -56,7 +56,14 @@ struct AllClickGameView: View {
                     }
                     .padding(.horizontal, 20)
                     
-                    Spacer()
+                    GeometryReader { geometry in
+                        ForEach(viewModel.subjects.indices, id: \.self) { index in
+                            AllClickTextRainView(subject: viewModel.subjects[index])
+                                .position(x: viewModel.subjects[index].xPosition,
+                                          y: viewModel.subjects[index].yPosition)
+                        }
+                    }
+                    .padding(.top, 10)
                     
                     HStack(spacing: 0) {
                         Spacer()
@@ -112,12 +119,6 @@ struct AllClickGameView: View {
                         Image(.brownPauseButton)
                     })
                 }, height: 57)
-                
-                ForEach(viewModel.subjects.indices, id: \.self) { index in
-                    AllClickTextRainView(subject: viewModel.subjects[index])
-                        .position(x: viewModel.subjects[index].xPosition,
-                                  y: viewModel.subjects[index].yPosition)
-                }
                 
                 if viewModel.isCountdownViewPresented {
                     CountdownView(countdown: $viewModel.countdown)

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameView.swift
@@ -57,14 +57,24 @@ struct AllClickGameView: View {
                     .padding(.horizontal, 20)
                     
                     GeometryReader { geometry in
-                        ForEach(viewModel.subjects.indices, id: \.self) { index in
-                            AllClickTextRainView(subject: viewModel.subjects[index])
-                                .position(x: viewModel.subjects[index].xPosition,
-                                          y: viewModel.subjects[index].yPosition)
+                        VStack{
+                            HStack {
+                                Spacer()
+                                
+                                VStack {
+                                    Spacer()
+                                }
+                            }
+                            .background(.yellow)
+                            .overlay {
+                                ForEach(viewModel.subjects.indices, id: \.self) { index in
+                                    AllClickTextRainView(subject: viewModel.subjects[index])
+                                        .position(x: viewModel.subjects[index].xPosition,
+                                                  y: viewModel.subjects[index].yPosition)
+                                }
+                            }
                         }
-                    }
-                    .onAppear {
-                        viewModel.setFrameXY(x: geometry.size.width, y: geometry.size.height)
+                        .clipped()
                     }
                     .padding(.top, 10)
                     

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
@@ -14,6 +14,10 @@ final class AllClickGameViewModel: GameViewModel {
     @Published var life: Int = 3
     @Published var subjects: [Subject] = []
     
+    // 글자 이동 제한
+    private var frameMaxX: CGFloat = 0.0
+    private var frameMaxY: CGFloat = 0.0
+    
     private var subjectRainTimer: Timer?
     let soundManager = SoundManager.shared
     
@@ -33,6 +37,11 @@ final class AllClickGameViewModel: GameViewModel {
         uploadResult(uploadScore: score)
     }
     
+    func setFrameXY(x: CGFloat, y: CGFloat) {
+        self.frameMaxX = x
+        self.frameMaxY = y
+    }
+    
     func startSubjectRain(withInterval interval: TimeInterval = 1.0) {
         var currentFallingCount = 0 // 현재까지 내려온 글자의 수
         var randomFallingCount = 1  // 랜덤으로 지정된 내려오는 횟수
@@ -48,9 +57,9 @@ final class AllClickGameViewModel: GameViewModel {
             var indicesToRemove: [Int] = []
             
             for i in self.subjects.indices {
-                self.subjects[i].yPosition += 20
+                self.subjects[i].yPosition += 12
                 
-                if self.subjects[i].yPosition >= 460 {
+                if self.subjects[i].yPosition >= frameMaxY {
                     indicesToRemove.append(i)
                 }
             }
@@ -96,7 +105,7 @@ final class AllClickGameViewModel: GameViewModel {
     
     func randomXPosition() -> CGFloat {
         var xPosition: CGFloat = 20
-        let temp = Int.random(in: 60...Int(UIScreen.main.bounds.width) - 60)
+        let temp = Int.random(in: 60...Int(frameMaxX) - 60)
         xPosition = CGFloat(temp)
         return xPosition
     }

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
@@ -14,10 +14,6 @@ final class AllClickGameViewModel: GameViewModel {
     @Published var life: Int = 3
     @Published var subjects: [Subject] = []
     
-    // 글자 이동 제한
-    private var frameMaxX: CGFloat = 0.0
-    private var frameMaxY: CGFloat = 0.0
-    
     private var subjectRainTimer: Timer?
     let soundManager = SoundManager.shared
     
@@ -37,11 +33,6 @@ final class AllClickGameViewModel: GameViewModel {
         uploadResult(uploadScore: score)
     }
     
-    func setFrameXY(x: CGFloat, y: CGFloat) {
-        self.frameMaxX = x
-        self.frameMaxY = y
-    }
-    
     func startSubjectRain(withInterval interval: TimeInterval = 1.0) {
         var currentFallingCount = 0 // 현재까지 내려온 글자의 수
         var randomFallingCount = 1  // 랜덤으로 지정된 내려오는 횟수
@@ -59,7 +50,7 @@ final class AllClickGameViewModel: GameViewModel {
             for i in self.subjects.indices {
                 self.subjects[i].yPosition += 12
                 
-                if self.subjects[i].yPosition >= frameMaxY {
+                if self.subjects[i].yPosition >= 350 {
                     indicesToRemove.append(i)
                 }
             }
@@ -105,7 +96,7 @@ final class AllClickGameViewModel: GameViewModel {
     
     func randomXPosition() -> CGFloat {
         var xPosition: CGFloat = 20
-        let temp = Int.random(in: 60...Int(frameMaxX) - 60)
+        let temp = Int.random(in: 60...Int(UIScreen.main.bounds.width) - 60)
         xPosition = CGFloat(temp)
         return xPosition
     }

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
@@ -73,7 +73,7 @@ final class AllClickGameViewModel: GameViewModel {
             
             // 내려오는 횟수가 랜덤으로 지정된 횟수일 때에만 새로운 글자를 추가.
             if currentFallingCount == randomFallingCount,
-                let newSubject = getLocalizedRandomSubject() {
+               let newSubject = getLocalizedRandomSubject() {
                 var subject = newSubject
                 subject.xPosition = self.randomXPosition()
                 subject.yPosition = 0

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickTextRainView.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickTextRainView.swift
@@ -13,7 +13,7 @@ struct AllClickTextRainView: View {
     var body: some View {
         ZStack {
             Text(subject.title)
-                .font(.neo15)
+                .font(.neo17)
                 .kerning(-0.41)
                 .foregroundStyle(subject.type == .basic ? .kuTimebarRed : .kuText)
                 .textRainStroke()


### PR DESCRIPTION
### 🐣Issue
closed #223 
<br/>

### 🐣Motivation
- 수강신청 ALL 클릭 QA 반영했습니다. 
<br/>

### 🐣Key Changes
- 타이핑하면 자동으로 없어짐 → 엔터를 눌러야만 없어지도록 변경
 - 홈 화면 갔다 오면 과목 명이 사라져있음 -> 이미 해결.
-  과목 명이 처음 낙하하는 위치가 ‘SCORE’ 와 목숨 아래에서 부터
→ 호은: 일감호살아남기 보면 뷰 범위를 제한하고 넘는 것들 hidden 처리하면 될듯!
 - 글씨체 크기 수정 및 속도 수정
글씨체 피그마와 크기가 다른 것 같음 너무 작음 (Android와 함께 수정) → 글씨 조금 더 키우면 될듯
속도가 너무 빠름 (Android와 함께 수정)
 - 텍스트가 없을 때 플레이스홀더 뜨도록 수정
<br/>

### 🐣Simulation

https://github.com/user-attachments/assets/dd9d803d-7bd5-4e7b-bc19-9158b92613af



<br/>

### 🐣To Reviewer

<br/>

### 🐣Reference

<br/>
