### PR TITLE
[Feat] #225 - MapView 지도 Span, Bound 제한 적용

### DIFF
--- a/playkuround-iOS/Views/Home/HomeView.swift
+++ b/playkuround-iOS/Views/Home/HomeView.swift
@@ -20,7 +20,14 @@ struct HomeView: View {
             ZStack {
                 Color.kuDarkGreen.ignoresSafeArea(.all)
                 
-                MapView(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
+                if #available(iOS 17, *) {
+                    VStack {
+                        Spacer()
+                        MapViewiOS17(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
+                    }
+                } else {
+                    MapViewiOS16(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
+                }
                 
                 Image(.homeBorder)
                     .resizable()

--- a/playkuround-iOS/Views/Map/MapView.swift
+++ b/playkuround-iOS/Views/Map/MapView.swift
@@ -9,11 +9,71 @@ import CoreLocation
 import MapKit
 import SwiftUI
 
-struct MapView: View {
+@available(iOS 17, *)
+struct MapViewiOS17 : View {
     @ObservedObject var mapViewModel: MapViewModel
     @ObservedObject var homeViewModel: HomeViewModel
     
-    @State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 37.542_634, longitude: 127.076_769), span: MKCoordinateSpan(latitudeDelta: 0.009, longitudeDelta: 0.009))
+    @State var mapCameraPosition = MapCameraPosition.camera(MapCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 37.542_634, longitude: 127.076_769), distance: 2000, heading: 0.0, pitch: 0))
+    
+    let mapCameraBounds: MapCameraBounds = MapCameraBounds(centerCoordinateBounds: MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 37.542_634, longitude: 127.076_769), span: MKCoordinateSpan(latitudeDelta: 0.008, longitudeDelta: 0.012)), minimumDistance: 700, maximumDistance: 3000)
+    
+    private let soundManager = SoundManager.shared
+    
+    init(mapViewModel: MapViewModel, homeViewModel: HomeViewModel) {
+        self.mapViewModel = mapViewModel
+        self.homeViewModel = homeViewModel
+    }
+    
+    var body: some View {
+        Map(initialPosition: mapCameraPosition, bounds: mapCameraBounds) {
+            ForEach(Array(homeViewModel.landmarkList.enumerated()), id: \.offset) { index, landmark in
+                Annotation("", coordinate: CLLocationCoordinate2D(latitude: landmark.latitude, longitude: landmark.longitude)) {
+                    Image(.landmarkFlag)
+                        .onTapGesture {
+                            homeViewModel.openLandmarkView(landmarkID: landmark.number)
+                            soundManager.playSound(sound: .buttonClicked)
+                        }
+                }
+            }
+            
+            Annotation("", coordinate: CLLocationCoordinate2D(latitude: mapViewModel.userLatitude, longitude: mapViewModel.userLongitude)) {
+                Image(.userAnnotation)
+            }
+        }
+        .onAppear {
+            mapViewModel.startUpdatingLocation()
+        }
+        .onDisappear {
+            mapViewModel.stopUpdatingLocation()
+        }
+    }
+}
+
+struct EquatableMKCoordinateRegion: Equatable {
+    var region: MKCoordinateRegion
+
+    static func == (lhs: EquatableMKCoordinateRegion, rhs: EquatableMKCoordinateRegion) -> Bool {
+        return lhs.region.center.latitude == rhs.region.center.latitude &&
+               lhs.region.center.longitude == rhs.region.center.longitude &&
+               lhs.region.span.latitudeDelta == rhs.region.span.latitudeDelta &&
+               lhs.region.span.longitudeDelta == rhs.region.span.longitudeDelta
+    }
+}
+
+@available(iOS 16, *)
+struct MapViewiOS16: View {
+    @ObservedObject var mapViewModel: MapViewModel
+    @ObservedObject var homeViewModel: HomeViewModel
+    
+    private let minLatitudeDelta: CLLocationDegrees = 0.002
+    private let maxLatitudeDelta: CLLocationDegrees = 0.011
+    private let kuBounds = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 37.541_384, longitude: 127.076_479),
+        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+    )
+    
+    @State private var region = EquatableMKCoordinateRegion(region: MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 37.542_634, longitude: 127.076_769), span: MKCoordinateSpan(latitudeDelta: 0.009, longitudeDelta: 0.009)))
     @State private var annotationList: [AnnotationWrapper] = []
     
     private let soundManager = SoundManager.shared
@@ -41,7 +101,7 @@ struct MapView: View {
     var body: some View {
         let sortedAnnList = annotationList.sorted { $0.landmark.number > $1.landmark.number }
         
-        Map(coordinateRegion: $region, annotationItems: sortedAnnList) { annotation in
+        Map(coordinateRegion: $region.region, annotationItems: sortedAnnList) { annotation in
             if annotation.type == .landmark {
                 MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: annotation.landmark.latitude, longitude: annotation.landmark.longitude)) {
                     // getAnnotation(annotation)
@@ -60,6 +120,10 @@ struct MapView: View {
                 }
             }
         }
+        .onChange(of: region) { newRegion in
+            enforceZoomLimits()
+            enforceRegionBounds()
+        }
         .onAppear {
             mapViewModel.startUpdatingLocation()
             self.annotationList = self.getAnnotationList()
@@ -67,6 +131,26 @@ struct MapView: View {
         .onDisappear {
             mapViewModel.stopUpdatingLocation()
         }
+    }
+    
+    private func enforceZoomLimits() {
+        if region.region.span.latitudeDelta < minLatitudeDelta {
+            region.region.span.latitudeDelta = minLatitudeDelta
+        } else if region.region.span.longitudeDelta < minLatitudeDelta {
+            region.region.span.longitudeDelta = minLatitudeDelta
+        }
+        
+        if region.region.span.latitudeDelta > maxLatitudeDelta {
+            region.region.span.latitudeDelta = maxLatitudeDelta
+        } else if region.region.span.longitudeDelta > maxLatitudeDelta {
+            region.region.span.longitudeDelta = maxLatitudeDelta
+        }
+    }
+    
+    private func enforceRegionBounds() {
+        let latitude = min(max(region.region.center.latitude, kuBounds.center.latitude - kuBounds.span.latitudeDelta / 2), kuBounds.center.latitude + kuBounds.span.latitudeDelta / 2)
+        let longitude = min(max(region.region.center.longitude, kuBounds.center.longitude - kuBounds.span.longitudeDelta / 2), kuBounds.center.longitude + kuBounds.span.longitudeDelta / 2)
+        region.region.center = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
     
     // iOS16의 MapKit에서 Landmark Ann과 User Ann을 하나로 합쳐주기 위한 wrapper 인터페이스
@@ -85,5 +169,12 @@ struct MapView: View {
 }
 
 #Preview {
-    MapView(mapViewModel: MapViewModel(rootViewModel: RootViewModel()), homeViewModel: HomeViewModel(rootViewModel: RootViewModel()))
+    ZStack {
+        if #available(iOS 17, *) {
+            MapViewiOS17(mapViewModel: MapViewModel(rootViewModel: RootViewModel()), homeViewModel: HomeViewModel(rootViewModel: RootViewModel()))
+        }
+        else {
+            MapViewiOS16(mapViewModel: MapViewModel(rootViewModel: RootViewModel()), homeViewModel: HomeViewModel(rootViewModel: RootViewModel()))
+        }
+    }
 }


### PR DESCRIPTION
### 🐣Issue
closed #225 
<br/>

### 🐣Motivation
MapView 지도 Span, Bound 제한 적용했습니다
<br/>

### 🐣Key Changes
1. iOS16, iOS17 이상 분기처리 구현했습니다
    - 분기처리를 한 이유는 iOS17에서 MapKit이 대규모 업데이트를 해서 MapBound 등이 공식 지원되기 때문입니다
    - iOS16에서는 `onChange(of: region)`을 사용해 직접 업데이트를 추적해가며 범위를 제한하는 방식
    - iOS17 이상에서는 공식으로 `mapCameraBound`를 지원하기 때문에 분기처리 하였습니다

```swift
if #available(iOS 17, *) {
    VStack {
        Spacer() // 이게 없으면 MapView에 SafeAreaPadding이 적용되지 않아 배경 색이 보이지 않음
        MapViewiOS17(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
    }
} else {
    MapViewiOS16(mapViewModel: mapViewModel, homeViewModel: homeViewModel)
}
```
<br/>

2. iOS16, iOS17 MapKit 두 개 모두 Span, Bound 범위 제한을 했습니다.
<br/>

### 🐣Simulation
| iOS16 | iOS17 |
|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/c1561a47-07e7-4026-b963-5bd4abc432fd"> | <img width="280px" src="https://github.com/user-attachments/assets/f70bec5b-b422-44ac-96af-9b61615f170d"> |
<br>

| iOS16 bound 시연 | iOS17 bound 시연 |
|--|--|
| <video width="280px" src="https://github.com/user-attachments/assets/aa8e0e28-b335-4290-acac-2ca66a9d3152"> | <video width="280px" src="https://github.com/user-attachments/assets/9b070e7a-6364-4437-a91e-f2d0b6d1e858"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
