### PR TITLE
[Fix] #234 - 로그인 QA 반영

### DIFF
--- a/playkuround-iOS.xcodeproj/project.pbxproj
+++ b/playkuround-iOS.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		0CA193592BB5B49A007C04B1 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0CA193582BB5B49A007C04B1 /* Pretendard-Bold.otf */; };
 		0CA4C5662BB3281F00268B07 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4C5652BB3281F00268B07 /* RootView.swift */; };
 		0CA82DB22C70B93400914DC4 /* ProfileBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA82DB12C70B93400914DC4 /* ProfileBadgeView.swift */; };
+		0CB029E22C833AAE00AA8182 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB029E12C833AA900AA8182 /* UIApplication+.swift */; };
 		0CB465AE2BB3D1C700317455 /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB465AD2BB3D1C700317455 /* RootViewModel.swift */; };
 		0CB50B1D2BFDB1330003FE3B /* SurviveGameEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB50B1C2BFDB1330003FE3B /* SurviveGameEntity.swift */; };
 		0CB76A282C73AF9900BDF364 /* LeadingFlexBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB76A272C73AF9500BDF364 /* LeadingFlexBox.swift */; };
@@ -226,6 +227,7 @@
 		0CA193582BB5B49A007C04B1 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		0CA4C5652BB3281F00268B07 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		0CA82DB12C70B93400914DC4 /* ProfileBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileBadgeView.swift; sourceTree = "<group>"; };
+		0CB029E12C833AA900AA8182 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		0CB465AD2BB3D1C700317455 /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
 		0CB50B1C2BFDB1330003FE3B /* SurviveGameEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurviveGameEntity.swift; sourceTree = "<group>"; };
 		0CB76A272C73AF9500BDF364 /* LeadingFlexBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeadingFlexBox.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 		0C6AA4B92BA4A32A0032AB24 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				0CB029E12C833AA900AA8182 /* UIApplication+.swift */,
 				C9519D372BB3338700F69974 /* ViewModifiers */,
 				C918F4032BA7148800C0BFDA /* Managers */,
 				C9519D3A2BB335EC00F69974 /* View+.swift */,
@@ -1069,6 +1072,7 @@
 				0C519D992BBAEB6C00DAA206 /* GameViewModel.swift in Sources */,
 				B98503C22BDCEC2900C3CC8F /* AllClickTextRainView.swift in Sources */,
 				0C6AA4CF2BA56FB30032AB24 /* ScoreType.swift in Sources */,
+				0CB029E22C833AAE00AA8182 /* UIApplication+.swift in Sources */,
 				C953D2FE2BA4807400318869 /* LoginView.swift in Sources */,
 				0C9B120E2C6F67C600093178 /* ToastAlertView.swift in Sources */,
 				C953D2F92BA47B4B00318869 /* Font.swift in Sources */,

--- a/playkuround-iOS/Extensions/UIApplication+.swift
+++ b/playkuround-iOS/Extensions/UIApplication+.swift
@@ -1,0 +1,19 @@
+//
+//  UIApplication+.swift
+//  playkuround-iOS
+//
+//  Created by Hoeun Lee on 8/31/24.
+//
+
+import SwiftUI
+import Combine
+
+// 키보드 닫기 함수
+extension UIApplication {
+    func dismissKeyboard() {
+        guard let windowScene = connectedScenes.first as? UIWindowScene else { return }
+        windowScene.windows
+            .first { $0.isKeyWindow }?
+            .endEditing(true)
+    }
+}

--- a/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/AllClickGame/AllClickGameViewModel.swift
@@ -165,13 +165,3 @@ final class AllClickGameViewModel: GameViewModel {
         return randomSubject
     }
 }
-
-// 키보드 닫기 함수
-extension UIApplication {
-    func dismissKeyboard() {
-        guard let windowScene = connectedScenes.first as? UIWindowScene else { return }
-        windowScene.windows
-            .first { $0.isKeyWindow }?
-            .endEditing(true)
-    }
-}

--- a/playkuround-iOS/Views/Login/LoginView.swift
+++ b/playkuround-iOS/Views/Login/LoginView.swift
@@ -52,7 +52,6 @@ struct LoginView: View {
                         TextField(NSLocalizedString("Login.PlaceHolder", comment: ""), text: $userId)
                             .font(.pretendard15R)
                             .kerning(-0.41)
-                            // .focused($focusField)
                             .focused($focusedField, equals: .userId)
                             .padding(.leading, 20)
                             .overlay {

--- a/playkuround-iOS/Views/Login/LoginView.swift
+++ b/playkuround-iOS/Views/Login/LoginView.swift
@@ -12,7 +12,7 @@ struct LoginView: View {
     
     // 포탈 아이디
     @State private var userId: String = ""
-    @FocusState private var focusField: Bool
+    // @FocusState private var focusField: Bool
     
     // 인증코드 요청
     @State private var mailButtonTitle = NSLocalizedString("Login.RequestCode", comment: "")
@@ -25,6 +25,9 @@ struct LoginView: View {
     @State private var isMaximumCount: Bool = false
     @State private var userSendingCount: Int?
     @State private var isAuthCodeViewVisible: Bool = false
+    
+    @State private var keyboardOffset: CGFloat = 0
+    @FocusState private var focusedField: FieldFocus?
     
     private let soundManager = SoundManager.shared
     
@@ -49,13 +52,14 @@ struct LoginView: View {
                         TextField(NSLocalizedString("Login.PlaceHolder", comment: ""), text: $userId)
                             .font(.pretendard15R)
                             .kerning(-0.41)
-                            .focused($focusField)
+                            // .focused($focusField)
+                            .focused($focusedField, equals: .userId)
                             .padding(.leading, 20)
                             .overlay {
                                 Text("Login.Email")
                                     .font(.pretendard15R)
                                     .foregroundStyle(.gray)
-                                    .opacity(userId.isEmpty && !focusField ? 0 : 1)
+                                    .opacity(userId.isEmpty && focusedField != .userId ? 0 : 1)
                                     .padding(.leading, 190)
                             }
                             .autocorrectionDisabled(true)
@@ -75,6 +79,8 @@ struct LoginView: View {
                     }
                     
                     callPOSTAPIemails(target: userId + NSLocalizedString("Login.Email", comment: ""))
+                    
+                    focusedField = .authCode
                     
                     if !isMaximumCount {
                         self.isAuthCodeViewVisible = true
@@ -103,11 +109,13 @@ struct LoginView: View {
                                            userSendingCount: $userSendingCount,
                                            isTimerFinished: $isBottomSheetPresented,
                                            userEmail: userId + NSLocalizedString("Login.Email", comment: ""))
+                    .focused($focusedField, equals: .authCode)
                 }
                 
                 Spacer()
             }
             .padding(.top, 80)
+            .offset(y: -keyboardOffset)
             
             // 인증 시간 초과 되었을 때
             if isBottomSheetPresented {
@@ -126,6 +134,23 @@ struct LoginView: View {
         }
         .onAppear {
             GAManager.shared.logScreenEvent(.LoginView)
+            NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
+                if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                    if focusedField == .authCode {
+                        withAnimation(.easeInOut) {
+                            keyboardOffset = keyboardFrame.height / 4
+                        }
+                    }
+                }
+            }
+            NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+                withAnimation(.easeInOut) {
+                    keyboardOffset = 0
+                }
+            }
+        }
+        .onTapGesture {
+            UIApplication.shared.dismissKeyboard()
         }
     }
     
@@ -178,6 +203,10 @@ struct LoginView: View {
     }
 }
 
+enum FieldFocus: Hashable {
+    case userId
+    case authCode
+}
 
 #Preview {
     LoginView(viewModel: RootViewModel())


### PR DESCRIPTION
### 🐣Issue
closed #234 
<br/>

### 🐣Motivation
로그인 QA를 반영합니다
- 인증번호 오류문구가 안보임 -> 키보드와 함께 뷰가 올라가도록 수정
- 밖을 클릭하면 키보드가 내려가도록 설정
<br/>

### 🐣Key Changes
1. LoginView 배경 클릭 시 키보드 내려가도록 처리
2. 아래 인증번호 칸에 focus 가 있는 경우 키보드와 함께 뷰가 올라가도록 처리
3. 기존 `AllClickGameViewModel`에 있던 `UIApplication Extension` 키보드 닫기 함수를 `UIApplication+.swift` 로 위치 옮김
4. 이메일 전송 버튼 클릭 시 포커스가 인증코드로 옮겨지도록 
<br/>

### 🐣Simulation
| 뷰 시연 |
|--|
 | <video width="280px" src="https://github.com/user-attachments/assets/3d2184ed-5d38-4f4f-af23-0c29b97945bc"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
- https://velog.io/@club2548/Swift-키보드가-화면을-가릴-때-뷰를-키보드-위쪽으로-이동시키는-방법NotificationCenter
<br/>
