### PR TITLE
[Fix] #239 - 이메일 인증번호 틀린 후 확인 버튼 반응 없는 오류 수정

### DIFF
--- a/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
+++ b/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
@@ -156,6 +156,7 @@ struct AuthenticationCodeView: View {
                         // 잘못된 인증코드를 입력했을 때
                         if apiResponse.errorResponse?.code == "E005" {
                             isAuthCodeWrong = true
+                            authButtonClicked = false
                         }
                     }
                 }

--- a/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
+++ b/playkuround-iOS/Views/Login/AuthenticationCodeView.swift
@@ -63,7 +63,7 @@ struct AuthenticationCodeView: View {
                 .padding(.top, 46)
             
             Button(action: {
-                authButtonClicked.toggle()
+                authButtonClicked = true
                 soundManager.playSound(sound: .buttonClicked
                 )
                 if !authCode.isEmpty && authButtonClicked {


### PR DESCRIPTION
### 🐣Issue
closed #239 
<br/>

### 🐣Motivation
이메일 인증번호 잘못 입력하고 한 번 틀린 후 올바른 번호 입력해도 확인 버튼 반응이 없는 오류 수정했습니다
<br/>

### 🐣Key Changes
기존 코드는 인증번호 확인 버튼을 누를 경우 `authButtonClicked = true`로 처리 후, 틀렸을 때 다시 이를 수정하는 코드가 없었음
인증번호 틀린 경우 `authButtonClicked = false`로 바꿔주는 코드 추가
추가적으로 버튼 눌렀을 때 toggle이 아니라 `authButtonClicked = true로 변경
<br/>

```swift
Button(action: {
    authButtonClicked = true // .toggle() → true로 변경
    soundManager.playSound(sound: .buttonClicked
    )
    if !authCode.isEmpty && authButtonClicked {
        callGETAPIemails(code: authCode, email: userEmail)
    }
}, label: {
    Image(authCode.isEmpty ? .longButtonGray : .longButtonBlue)
        .overlay {
            Text("Login.Authentication")
                .font(.neo15)
                .foregroundStyle(.kuText)
                .kerning(-0.41)
        }
})
.disabled(authCode.isEmpty)

// ....

else {
    // 잘못된 인증코드를 입력했을 때
    if apiResponse.errorResponse?.code == "E005" {
        isAuthCodeWrong = true
        authButtonClicked = false // 추가
    }
}
```
<br/>

### 🐣Simulation
| 시연 |
|--|
| <video width="280px" src="https://github.com/user-attachments/assets/13543190-722f-43bc-9634-e62b6937c16e"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
