### PR TITLE
[Fix] #243 - 랜드마크 랭킹 뷰 폰트 깨짐 수정

### DIFF
--- a/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
+++ b/playkuround-iOS/Views/Home/Landmark/LandmarkRankingView.swift
@@ -61,32 +61,6 @@ struct LandmarkRankingView: View {
                                         .frame(height: 24)
                                     
                                     VStack(alignment: .center, spacing: 5) {
-                                        /* Text(homeViewModel.getSelectedLandmark().name)
-                                            .font(.neo18)
-                                            .foregroundColor(.kuTextDarkGreen)
-                                            .kerning(-0.41) +
-                                        
-                                        Text(StringLiterals.Home.Landmark.rankingSubtext1)
-                                            .font(.neo18)
-                                            .foregroundColor(.kuText)
-                                            .kerning(-0.41)
-                                        
-                                        Text(StringLiterals.Home.Landmark.rankingSubtext2)
-                                            .font(.neo18)
-                                            .foregroundColor(.kuText)
-                                            .kerning(-0.41)
-                                        
-                                        // 1등 플레이어 닉네임
-                                        Text(rankingList[0].nickname)
-                                            .font(.neo18)
-                                            .foregroundColor(.kuTextDarkGreen)
-                                            .kerning(-0.41) +
-                                        
-                                        Text(StringLiterals.Home.Landmark.rankingSubtext3)
-                                            .font(.neo18)
-                                            .foregroundColor(.kuText)
-                                            .kerning(-0.41)*/
-                                        
                                         let originalString = NSLocalizedString("Home.Landmark.RankingSubtext", comment: "")
                                         
                                         let replacedString = originalString
@@ -94,9 +68,15 @@ struct LandmarkRankingView: View {
                                             .replacingOccurrences(of: "[NICKNAME]", with: rankingList[0].nickname)
                                             .replacingOccurrences(of: "<br>", with: "\n")
                                         
-                                        Text(replacedString)
+                                        TextWithColorSubstring(originalText: replacedString,
+                                                               colorSubText1: homeViewModel.getSelectedLandmark().name,
+                                                               colorSubText2: rankingList[0].nickname,
+                                                               regularFont: .neo18,
+                                                               regularColor: .kuText,
+                                                               color: .kuTextDarkGreen)
                                             .multilineTextAlignment(.center)
                                             .lineLimit(nil)
+                                            .kerning(-0.41)
                                     }
                                     
                                     Spacer()
@@ -215,6 +195,63 @@ struct LandmarkRankingView: View {
                 GAManager.shared.logScreenEvent(.LandmarkRankingView,
                                                 landmarkID: homeViewModel.getSelectedLandmark().number)
             }
+        }
+    }
+}
+
+struct TextWithColorSubstring: View {
+    let originalText: String
+    let colorSubText1: String
+    let colorSubText2: String
+    let regularFont: Font
+    let regularColor: Color
+    let color: Color
+
+    var body: some View {
+        // 첫 번째 colorSubText1 범위 탐색
+        if let colorRange1 = originalText.range(of: colorSubText1) {
+            let beforeRange1 = originalText[..<colorRange1.lowerBound]
+            let colorText1 = originalText[colorRange1]
+            let afterRange1 = originalText[colorRange1.upperBound...]
+            
+            // 두 번째 colorSubText2 범위 탐색
+            if let colorRange2 = afterRange1.range(of: colorSubText2) {
+                let beforeRange2 = afterRange1[..<colorRange2.lowerBound]
+                let colorText2 = afterRange1[colorRange2]
+                let afterRange2 = afterRange1[colorRange2.upperBound...]
+                
+                return Text(beforeRange1)
+                    .font(regularFont)
+                    .foregroundColor(regularColor)
+                + Text(colorText1)
+                    .font(regularFont)
+                    .foregroundColor(color)
+                + Text(beforeRange2)
+                    .font(regularFont)
+                    .foregroundColor(regularColor)
+                + Text(colorText2)
+                    .font(regularFont)
+                    .foregroundColor(color)
+                + Text(afterRange2)
+                    .font(regularFont)
+                    .foregroundColor(regularColor)
+            } else {
+                // colorSubText2가 없을 경우
+                return Text(beforeRange1)
+                    .font(regularFont)
+                    .foregroundColor(regularColor)
+                + Text(colorText1)
+                    .font(regularFont)
+                    .foregroundColor(color)
+                + Text(afterRange1)
+                    .font(regularFont)
+                    .foregroundColor(regularColor)
+            }
+        } else {
+            // colorSubText1이 없을 경우
+            return Text(originalText)
+                .font(regularFont)
+                .foregroundColor(regularColor)
         }
     }
 }


### PR DESCRIPTION
### 🐣Issue
closed #243 
<br/>

### 🐣Motivation
랜드마크 랭킹 뷰 폰트 깨짐 수정했습니다
<br/>

### 🐣Key Changes
다국어 작업 하면서 랜드마크 랭킹 쪽 폰트가 깨져있는걸 발견하여 수정하였습니다
<img width="300px" src="https://github.com/user-attachments/assets/b9d54459-4982-46ee-8be2-8770fd86909d">
<br/>

### 🐣Simulation
**수정 후**
| 한국어 | 영어 | 중국어 |
|--|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/004b8f69-9169-4b89-9e26-205d680b73d6"> | <img width="280px" src="https://github.com/user-attachments/assets/27a73da0-78df-4ea0-8b4c-2b8f8c00d350"> | <img width="280px" src="https://github.com/user-attachments/assets/c25881d9-28ae-4378-8d6c-19843a7fe962"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
