### PR TITLE
[Fix] #250 - QA 수정사항 4차 반영

### DIFF
--- a/playkuround-iOS/Resources/Localizable.xcstrings
+++ b/playkuround-iOS/Resources/Localizable.xcstrings
@@ -1246,7 +1246,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[LANDMARK]을 <br>제일 많이 정복한 사람은 <br>[NICKNAME]님입니다"
+            "value" : "[LANDMARK]을/를 <br>제일 많이 정복한 사람은 <br>[NICKNAME]님입니다"
           }
         },
         "zh-Hans" : {

--- a/playkuround-iOS/ViewModels/RootViewModel.swift
+++ b/playkuround-iOS/ViewModels/RootViewModel.swift
@@ -282,6 +282,16 @@ final class RootViewModel: ObservableObject {
         }
     }
     
+    // 토스트 메시지 바로 닫기
+    func closeToastMessageView() {
+        DispatchQueue.main.async {
+            self.toastMessage = nil
+            withAnimation(.easeInOut(duration: 0.3)) {
+                self.toastMessageShowing = false
+            }
+        }
+    }
+    
     // 설정 열기
     func openSetting() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }

--- a/playkuround-iOS/Views/MyPage/MyPageProfileView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageProfileView.swift
@@ -43,6 +43,9 @@ struct MyPageProfileView: View {
             }
 
             Image(.mypageCurrentScore)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: .infinity)
                 .overlay(currentScoreOverlay)
                 .padding(.top, 15)
 
@@ -65,8 +68,12 @@ struct MyPageProfileView: View {
             }
 
             Image(.mypageHighestScore)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: .infinity)
                 .overlay(highestScoreOverlay)
         }
+        .padding(.horizontal, 20)
     }
     
     private func getLocalizedMajorName() -> String? {

--- a/playkuround-iOS/Views/MyPage/MyPageView.swift
+++ b/playkuround-iOS/Views/MyPage/MyPageView.swift
@@ -68,21 +68,6 @@ struct MyPageView: View {
             }
             .padding(.top, 100)
             
-            if isStoryViewPresented {
-                StoryView(rootViewModel: viewModel, showStoryView: $isStoryViewPresented)
-            }
-            else if isLogoutPresented {
-                CheckLogoutView(viewModel: viewModel,
-                                isLogoutPresented: $isLogoutPresented)
-            }
-            else if isCheerPresented {
-                CheerPKTeamView()
-            }
-            else if isDeleteAccountPresented {
-                CheckDeleteAccountView(viewModel: viewModel,
-                                       isDeleteAccountPresented: $isDeleteAccountPresented)
-            }
-            
             Spacer()
                 .customNavigationBar(
                     centerView: {
@@ -98,6 +83,21 @@ struct MyPageView: View {
                             Image(.leftBlackArrow)
                         })
                     }, height: 73)
+            
+            if isStoryViewPresented {
+                StoryView(rootViewModel: viewModel, showStoryView: $isStoryViewPresented)
+            }
+            else if isLogoutPresented {
+                CheckLogoutView(viewModel: viewModel,
+                                isLogoutPresented: $isLogoutPresented)
+            }
+            else if isCheerPresented {
+                CheerPKTeamView()
+            }
+            else if isDeleteAccountPresented {
+                CheckDeleteAccountView(viewModel: viewModel,
+                                       isDeleteAccountPresented: $isDeleteAccountPresented)
+            }
         }
         .fullScreenCover(isPresented: $isServiceTermsViewPresented) {
             TermsView(title: NSLocalizedString("Register.ServiceTermsTitle", comment: "") , termsType: .service)
@@ -146,4 +146,8 @@ enum MyPageSection {
     case Setting
     case Shortcut
     case Instruction
+}
+
+#Preview {
+    MyPageView(viewModel: RootViewModel(), homeViewModel: HomeViewModel(rootViewModel: RootViewModel()))
 }

--- a/playkuround-iOS/Views/Root/RootView.swift
+++ b/playkuround-iOS/Views/Root/RootView.swift
@@ -84,7 +84,7 @@ struct RootView: View {
             // 토스트 메시지 (최상단)
             if viewModel.toastMessageShowing {
                 if let message = viewModel.toastMessage {
-                    ToastAlertView(alertText: message)
+                    ToastAlertView(rootViewModel: viewModel, alertText: message)
                 }
             }
             

--- a/playkuround-iOS/Views/Root/ToastAlertView.swift
+++ b/playkuround-iOS/Views/Root/ToastAlertView.swift
@@ -8,11 +8,16 @@
 import SwiftUI
 
 struct ToastAlertView: View {
+    @ObservedObject var rootViewModel: RootViewModel
     let alertText: String
     
     var body: some View {
         ZStack {
             Color.black.opacity(0.5).ignoresSafeArea()
+                .onTapGesture {
+                    rootViewModel.closeToastMessageView()
+                }
+            
             Image(.toastAlert)
                 .overlay {
                     HStack(alignment: .center, spacing: 10) {
@@ -29,5 +34,5 @@ struct ToastAlertView: View {
 }
 
 #Preview {
-    ToastAlertView(alertText: "서버에 연결할 수 없습니다.\n잠시 후 다시 시도해주세요. 테스트 테스트 테스트")
+    ToastAlertView(rootViewModel: RootViewModel(), alertText: "서버에 연결할 수 없습니다.\n잠시 후 다시 시도해주세요. 테스트 테스트 테스트")
 }


### PR DESCRIPTION
### 🐣Issue
closed #250 
<br/>

### 🐣Motivation
QA 수정사항 4차 반영합니다
<br/>

### 🐣Key Changes
1. 토스트 메시지 배경 클릭 시 닫히도록 처리
2. 정복랭킹 워딩 수정 "을" → "을/를"
3. 마이페이지 Navigation바 z 조정
    - 네비게이션바 보다 로그아웃 확인, 응원 뷰들이 아래에 있어서 위로 수정
4. 마이페이지 패딩 조정
    - 마이페이지 하단 섹션과 프로필 (점수) 섹션 패딩이 다른 문제 해결
<br/>

### 🐣Simulation
**1. 배경 클릭 시 토스트 메시지 닫히도록 처리**
| 시연 |
|--|
| <video width="280px" src="https://github.com/user-attachments/assets/94669483-c345-454d-81fc-46d4dc938a52"> |
<br>

**2. 랜드마크 정복랭킹 텍스트 수정**
| 수정 후 |
|--|
| <img width="280px" alt="image" src="https://github.com/user-attachments/assets/47170779-b12f-4178-a567-57f856d8d516"> |
<br>

**3. 마이페이지 Navigation 바 z 순서 조정**
| 수정 전 | 수정 후 |
|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/a444bd8f-b058-43e8-9a01-2c61e5b21e45"> | <img width="280px" src="https://github.com/user-attachments/assets/c7dbd2fd-b727-4009-a277-15ef4caeae7c"> |
<br>

**4. 마이페이지 패딩 수정**
| 수정 전 | 5.5" | 6.5" | 6.7" |
|--|--|--|--|
| <img width="280px" src="https://github.com/user-attachments/assets/ef6d7c99-6aa8-4cb0-81c0-a47344ef335c"> | <img width="280px" src="https://github.com/user-attachments/assets/7b9b30c6-28b4-4bc7-b34e-5556cafee702"> | <img width="280px" src="https://github.com/user-attachments/assets/3db27b06-2259-4e86-860b-869d546c7811"> | <img width="280px" src="https://github.com/user-attachments/assets/6cc5b251-a25c-49dd-97eb-87666e0fedb0"> |
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
