### PR TITLE
[Fix] #258 - 일감호에서 살아남기 생명 깎이지 않는 오류 수정

### DIFF
--- a/playkuround-iOS/Views/Games/SurviveGame/SurviveGameViewModel.swift
+++ b/playkuround-iOS/Views/Games/SurviveGame/SurviveGameViewModel.swift
@@ -227,7 +227,7 @@ final class SurviveGameViewModel: GameViewModel {
     }
     
     func duckkuHit() {
-        // self.life -= 1
+        self.life -= 1
         
         if self.life == 0 {
             soundManager.playSound(sound: .microbeEnd)


### PR DESCRIPTION
### 🐣Issue
closed #258 
<br/>

### 🐣Motivation
일감호에서 살아남기 생명 깎이지 않는 오류 수정했습니다
<br/>

### 🐣Key Changes
아까 디버깅하느라 주석처리 해두었던 생명 차감 코드를 까먹고 주석 해제를 안해서 주석 해제했습니다
<br/>

```swift
func duckkuHit() {
    self.life -= 1 // 주석 해제
    
    if self.life == 0 {
        soundManager.playSound(sound: .microbeEnd)
        finishGame()
    } else {
        soundManager.playSound(sound: .microbeHit)
    }
    
    DispatchQueue.main.async {
        self.isImmuned = true
        self.isTransparent = true
        self.toggleTransparency(0)
    }
    
    // 3초 후 무적 해제
    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
        self.isTransparent = false
        self.isImmuned = false
    }
}
```
<br/>

### 🐣Simulation
X
<br/>

### 🐣To Reviewer
X
<br/>

### 🐣Reference
X
<br/>
